### PR TITLE
Move BrowserLink.Runtime into its own .NET Core package.

### DIFF
--- a/BrowserLink.sln
+++ b/BrowserLink.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{24D02C4B-DF8B-4D12-9F28-566302D585C8}"
 	ProjectSection(SolutionItems) = preProject
@@ -11,6 +11,12 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7AC709A9-E84C-4C8F-8185-8A3D01DD7D7C}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.VisualStudio.Web.BrowserLink.Loader", "src\Microsoft.VisualStudio.Web.BrowserLink.Loader\Microsoft.VisualStudio.Web.BrowserLink.Loader.xproj", "{C31202E6-FC58-4354-B2D2-ACD1B3118C05}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.VisualStudio.Web.BrowserLink", "src\Microsoft.VisualStudio.Web.BrowserLink\Microsoft.VisualStudio.Web.BrowserLink.xproj", "{616F445C-7A41-4E61-98E3-1B70D70F9F09}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{7F6F47EA-CAF5-46E2-B29C-8B20291185B7}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.VisualStudio.Web.BrowserLink.Test", "test\Microsoft.VisualStudio.Web.BrowserLink.Test\Microsoft.VisualStudio.Web.BrowserLink.Test.xproj", "{96146399-2C42-4CAA-ABCD-CF1E0F000CEC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,11 +28,21 @@ Global
 		{C31202E6-FC58-4354-B2D2-ACD1B3118C05}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C31202E6-FC58-4354-B2D2-ACD1B3118C05}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C31202E6-FC58-4354-B2D2-ACD1B3118C05}.Release|Any CPU.Build.0 = Release|Any CPU
+		{616F445C-7A41-4E61-98E3-1B70D70F9F09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{616F445C-7A41-4E61-98E3-1B70D70F9F09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{616F445C-7A41-4E61-98E3-1B70D70F9F09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{616F445C-7A41-4E61-98E3-1B70D70F9F09}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96146399-2C42-4CAA-ABCD-CF1E0F000CEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96146399-2C42-4CAA-ABCD-CF1E0F000CEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96146399-2C42-4CAA-ABCD-CF1E0F000CEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96146399-2C42-4CAA-ABCD-CF1E0F000CEC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{C31202E6-FC58-4354-B2D2-ACD1B3118C05} = {7AC709A9-E84C-4C8F-8185-8A3D01DD7D7C}
+		{616F445C-7A41-4E61-98E3-1B70D70F9F09} = {7AC709A9-E84C-4C8F-8185-8A3D01DD7D7C}
+		{96146399-2C42-4CAA-ABCD-CF1E0F000CEC} = {7F6F47EA-CAF5-46E2-B29C-8B20291185B7}
 	EndGlobalSection
 EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,3 +1,3 @@
 {
-  "projects": [ "src" ]
+  "projects": [ "src", "test" ]
 }

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/AssemblyInfo.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyMetadata("Serviceable", "True")]
+[assembly: NeutralResourcesLanguage("en-us")]
+[assembly: AssemblyCompany("Microsoft Corporation.")]
+[assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: AssemblyProduct("Microsoft Visual Studio")]
+
+[assembly: InternalsVisibleTo("Microsoft.VisualStudio.Web.BrowserLink.Test, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
+

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/BrowserLinkExtensions.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/BrowserLinkExtensions.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.VisualStudio.Web.BrowserLink;
+
+namespace Microsoft.AspNetCore.Builder
+{
+    /// <summary>
+    /// Implementation of extension methods for configuring Browser Link
+    /// in an ASP.NET Core application.
+    /// </summary>
+    public static class BrowserLinkExtensions
+    {
+        /// <summary>
+        /// This method is called to enable Browser Link in an application. It
+        /// registers a factory method that creates BrowserLinkMiddleware for
+        /// each request.
+        /// </summary>
+        public static IApplicationBuilder UseBrowserLink(this IApplicationBuilder app)
+        {
+            if (!IsMicrosoftRuntime)
+            {
+                return app;
+            }
+
+            try
+            {
+                string applicationBasePath;
+
+                if (GetApplicationBasePath(app, out applicationBasePath))
+                {
+                    applicationBasePath = PathUtil.NormalizeDirectoryPath(applicationBasePath);
+
+                    HostConnectionUtil.SignalHostForStartup(applicationBasePath, blockUntilStarted: false);
+
+                    BrowserLinkMiddlewareFactory factory = new BrowserLinkMiddlewareFactory(applicationBasePath);
+
+                    return app.Use(factory.CreateBrowserLinkMiddleware);
+                }
+                else
+                {
+                    // Browser Link doesn't work if we don't have an application path
+                    return app;
+                }
+            }
+            catch
+            {
+                // Something went wrong initializing the runtime. Browser Link won't work. 
+                return app;
+            }
+        }
+
+        private static bool IsMicrosoftRuntime
+        {
+            get { return Type.GetType("Mono.Runtime") == null; }
+        }
+
+        private static bool GetApplicationBasePath(IApplicationBuilder app, out string applicationBasePath)
+        {
+            IHostingEnvironment hostingEnvironment = app.ApplicationServices.GetService(typeof(IHostingEnvironment)) as IHostingEnvironment;
+
+            if (hostingEnvironment != null)
+            {
+                applicationBasePath = hostingEnvironment.ContentRootPath;
+
+                return applicationBasePath != null;
+            }
+
+            applicationBasePath = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/BrowserLinkMiddleWare.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/BrowserLinkMiddleWare.cs
@@ -1,0 +1,211 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// This class is created once, and invoked for each request. It puts a filter on
+    /// the Response.Body, which will inject Browser Link's script links into the
+    /// content (if the content is HTML).
+    /// </summary>
+    internal class BrowserLinkMiddleware
+    {
+        // Number of timeouts allowed before we stop trying to connect to the host
+        private const int FilterRequestTimeoutLimit = 2;
+
+        // Number of timeouts that occurred while attempting to connect to the host
+        private static int _filterRequestTimeouts = 0;
+
+        private RequestDelegate _next;
+        private string _applicationPath;
+
+        internal BrowserLinkMiddleware(string applicationPath, RequestDelegate next)
+        {
+            _applicationPath = applicationPath;
+            _next = next;
+        }
+
+        /// <summary>
+        /// This method is called to process the response.
+        /// </summary>
+        internal Task Invoke(HttpContext context)
+        {
+            string requestId = Guid.NewGuid().ToString("N");
+
+            IHttpSocketAdapter injectScriptSocket = GetSocketConnectionToHost(_applicationPath, requestId, "injectScriptLink", context.Request.IsHttps);
+
+            if (injectScriptSocket != null)
+            {
+                return ExecuteWithFilter(injectScriptSocket, requestId, context);
+            }
+            else
+            {
+                return ExecuteWithoutFilter(context);
+            }
+        }
+
+        private PageExecutionListenerFeature AddPageExecutionListenerFeatureTo(HttpContext context, string requestId)
+        {
+            IHttpSocketAdapter mappingDataSocket = GetSocketConnectionToHost(_applicationPath, requestId, "sendMappingData", context.Request.IsHttps);
+
+            if (mappingDataSocket != null)
+            {
+                PageExecutionListenerFeature listener = new PageExecutionListenerFeature(mappingDataSocket);
+
+                context.Features.Set(listener);
+
+                return listener;
+            }
+
+            return null;
+        }
+
+        private async Task ExecuteWithFilter(IHttpSocketAdapter injectScriptSocket, string requestId, HttpContext httpContext)
+        {
+            ScriptInjectionFilterContext filterContext = new ScriptInjectionFilterContext(httpContext);
+
+            using (ScriptInjectionFilterStream filter = new ScriptInjectionFilterStream(injectScriptSocket, filterContext))
+            {
+                httpContext.Response.Body = filter;
+                httpContext.Response.OnStarting(delegate ()
+                {
+                    httpContext.Response.ContentLength = null;
+
+                    return StaticTaskResult.True;
+                });
+
+                using (AddPageExecutionListenerFeatureTo(httpContext, requestId))
+                {
+                    await _next(httpContext);
+
+                    await filter.WaitForFilterComplete();
+
+                    if (filter.ScriptInjectionTimedOut)
+                    {
+                        _filterRequestTimeouts++;
+                    }
+                    else
+                    {
+                        _filterRequestTimeouts = 0;
+                    }
+                }
+            }
+        }
+
+        private Task ExecuteWithoutFilter(HttpContext context)
+        {
+            return _next(context);
+        }
+
+        private static IHttpSocketAdapter GetSocketConnectionToHost(string applicationPath, string requestId, string rpcMethod, bool isHttps)
+        {
+            // The host should send an initial response immediately after
+            // the connection is established. If it fails to do so multiple times,
+            // stop trying. Each timeout is delaying a response to the browser.
+            //
+            // This will only reset when the server process is restarted.
+            if (_filterRequestTimeouts >= FilterRequestTimeoutLimit)
+            {
+                return null;
+            }
+
+            if (FindAndSignalHostConnection(applicationPath))
+            {
+                return new DelayConnectingHttpSocketAdapter(async delegate()
+                {
+                    Uri connectionString;
+
+                    if (GetHostConnectionString(applicationPath, out connectionString))
+                    {
+                        IHttpSocketAdapter httpSocket = await HttpSocketAdapter.OpenHttpSocketAsync("GET", new Uri(connectionString, rpcMethod));
+
+                        AddRequestHeaders(httpSocket, requestId, isHttps);
+
+                        return httpSocket;
+                    }
+
+                    return null;
+                });
+            }
+
+            return null;
+        }
+
+        private static void AddRequestHeaders(IHttpSocketAdapter httpSocket, string requestId, bool isHttps)
+        {
+            httpSocket.AddRequestHeader(BrowserLinkConstants.RequestIdHeaderName, requestId);
+
+            if (isHttps)
+            {
+                httpSocket.AddRequestHeader(BrowserLinkConstants.RequestScheme, "https");
+            }
+            else
+            {
+                httpSocket.AddRequestHeader(BrowserLinkConstants.RequestScheme, "http");
+            }
+        }
+
+        private static bool FindAndSignalHostConnection(string applicationPath)
+        {
+            HostConnectionData connectionData;
+
+            if (HostConnectionUtil.FindHostConnection(applicationPath, out connectionData))
+            {
+                return HostConnectionUtil.SignalHostForStartup(connectionData, blockUntilStarted: false);
+            }
+
+            return false;
+        }
+
+        private static bool GetHostConnectionString(string applicationPath, out Uri connectionString)
+        {
+            HostConnectionData connectionData;
+
+            if (GetHostConnectionData(applicationPath, out connectionData))
+            {
+                return Uri.TryCreate(connectionData.ConnectionString, UriKind.Absolute, out connectionString);
+            }
+
+            connectionString = null;
+            return false;
+        }
+
+        private static bool GetHostConnectionData(string applicationPath, out HostConnectionData connectionData)
+        {
+            if (HostConnectionUtil.FindHostConnection(applicationPath, out connectionData))
+            {
+                return EnsureHostServerStarted(applicationPath, ref connectionData);
+            }
+
+            connectionData = null;
+            return false;
+        }
+
+        private static bool EnsureHostServerStarted(string applicationPath, ref HostConnectionData connectionData)
+        {
+            if (String.IsNullOrEmpty(connectionData.ConnectionString))
+            {
+                if (!HostConnectionUtil.SignalHostForStartup(connectionData))
+                {
+                    return false;
+                }
+
+                if (!HostConnectionUtil.FindHostConnection(applicationPath, out connectionData))
+                {
+                    return false;
+                }
+
+                if (String.IsNullOrEmpty(connectionData.ConnectionString))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/BrowserLinkMiddlewareFactory.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/BrowserLinkMiddlewareFactory.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// An instance of this class is created when Browser Link is registered
+    /// in an application. It's job is to remember the base path of the
+    /// application, so it can be passed on to the BrowserLinkMiddleware.
+    /// </summary>
+    internal class BrowserLinkMiddlewareFactory
+    {
+        private string _applicationBasePath;
+
+        internal BrowserLinkMiddlewareFactory(string applicationBasePath)
+	    {
+            _applicationBasePath = applicationBasePath;
+	    }
+
+        public RequestDelegate CreateBrowserLinkMiddleware(RequestDelegate next)
+        {
+            BrowserLinkMiddleware middleware = new BrowserLinkMiddleware(_applicationBasePath, next);
+
+            return middleware.Invoke;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/Common/ArteryConstants.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/Common/ArteryConstants.cs
@@ -1,0 +1,184 @@
+using System;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// Well-known strings that are shared between the EurekaPackage in Visual Studio
+    /// and the HttpModule running in ASP.NET.
+    /// </summary>
+    internal static class BrowserLinkConstants
+    {
+        /// <summary>
+        /// Name of the index file when VS is elevated. This file can be accessed
+        /// by any user, including the IIS user.
+        /// </summary>
+        public const string ElevatedIndexFileName = @"Global\PageInspector.Artery";
+
+        /// <summary>
+        /// Name of the index file when VS is not elevated. This file can only be
+        /// accessed by the current user, i.e. not by IIS.
+        /// </summary>
+        public const string NonElevatedIndexFileName = "PageInspector.Artery";
+
+        public static readonly string[] IndexFileNames = new string[] 
+        {
+            ElevatedIndexFileName,
+            NonElevatedIndexFileName,
+        };
+
+        /// <summary>
+        /// Suffix appended to the instance file name to get the name of the
+        /// Request Signal, which is set to indicate that Artery should start.
+        /// </summary>
+        public const string RequestSignalSuffix = ".RequestSignal";
+
+        /// <summary>
+        /// Suffix appended to the instance file name to get the name of the 
+        /// Ready Signal, which blocks ASP.NET until the Artery server is ready.
+        /// </summary>
+        public const string ReadySignalSuffix = ".ReadySignal";
+
+        /// <summary>
+        /// Request header sent from the Browser Link runtime to identify which
+        /// page request the messages correspond to.
+        /// </summary>
+        public const string RequestIdHeaderName = "BrowserLink-RequestID";
+
+        /// <summary>
+        /// Request sent from the Browser Link runtime to identify whether it's
+        /// a "http" one or a "https" one.
+        /// </summary>
+        public const string RequestScheme = "Scheme";
+
+        /// <summary>
+        /// Constants representing the type of mapping data to follow
+        /// </summary>
+        public enum MappingDataType
+        {
+            /// <summary>
+            /// This value is never sent over the wire. It is used internally for data
+            /// blocks that are unrecognized by the receiver.
+            /// </summary>
+            Unknown = 0,
+
+            /// <summary>
+            /// Push a source context onto the stack. Data to follow includes:
+            ///     SourceStartPosition
+            ///     SourceLength
+            ///     SourceFilePath
+            ///     RenderedPosition
+            ///     RenderedOutputIndex
+            ///     IsLiteral
+            /// </summary>
+            BeginContext = 1,
+
+            /// <summary>
+            /// Pop a source context from the stack. Data to follow includes:
+            ///     RenderedOutputIndex
+            ///     RenderedPosition
+            /// </summary>
+            EndContext = 2,
+
+            /// <summary>
+            /// Define a rendered output. Data to follow includes:
+            ///     RenderedOutputIndex
+            ///     RenderedContent
+            /// </summary>
+            RenderedOutputDefinition = 3,
+
+            /// <summary>
+            /// Define a relationship between to rendered outputs. Data to follow includes:
+            ///     ParentRenderedOutputIndex
+            ///     ChildRenderedOutputindex
+            ///     RelativeRenderedPosition
+            /// </summary>
+            RenderedOutputRelationship = 4,
+
+            /// <summary>
+            /// Mapping data is complete.
+            /// </summary>
+            EndOfData = 5,
+        }
+
+        public enum MappingDataValueType
+        {
+            UnknownValue = 0,
+            Int32Value   = 1,
+            BooleanValue = 2,
+            StringValue  = 3,
+        }
+
+        public enum MappingDataValue
+        {
+            /// <summary>
+            /// (Int32) The first character position of the range of the source file
+            /// that is currently being rendered.
+            /// </summary>
+            SourceStartPosition = 1,
+
+            /// <summary>
+            /// (Int32) The length of the range of the source file that is currently
+            /// being rendered.
+            /// </summary>
+            SourceLength = 2,
+
+            /// <summary>
+            /// (string) The path to the source file that is currently being rendered.
+            /// </summary>
+            SourceFilePath = 3,
+
+            /// <summary>
+            /// (Int32) The current position in the rendered output that is being written.
+            /// </summary>
+            RenderedPosition = 4,
+
+            /// <summary>
+            /// (Int32) The index of the rendered output that is being written.
+            /// </summary>
+            RenderedOutputIndex = 5,
+
+            /// <summary>
+            /// (string) The final content of a rendered output
+            /// </summary>
+            RenderedContent = 6,
+
+            /// <summary>
+            /// (Boolean) True if a source range is being exactly copied from the source
+            /// file to the rendered output. This means character-by-character mapping
+            /// can be done in this source range.
+            /// </summary>
+            IsLiteral = 7,
+
+
+            /// <summary>
+            /// (Int32) For a rendered output relationship, this is the index of the
+            /// rendered output that will contain the other output.
+            /// </summary>
+            ParentRenderedOutputIndex = 11,
+
+            /// <summary>
+            /// (Int32) For a rendered output relationship, this is the index of the
+            /// rendered output that is contained by the other output.
+            /// </summary>
+            ChildRenderedOutputIndex = 12,
+
+            /// <summary>
+            /// (Int32) For a rendered output relationship, this is the position where
+            /// the parent rendered output will contain the child rendered output.
+            /// </summary>
+            RelativeRenderedPosition = 13,
+
+            
+            /// <summary>
+            /// No more data values in this block.
+            /// </summary>
+            EndOfDataValues = -1
+        }
+
+        /// <summary>
+        /// Preamble bytes that are returned from BrowserLinkFilterOwinModule to force
+        /// headers to be returned early.
+        /// </summary>
+        public static readonly byte[] FilterPreamble = new byte[] { 0xFF };
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/ContentTypeUtil.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/ContentTypeUtil.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// Helpers for testing the content type of the response content.
+    /// </summary>
+    internal static class ContentTypeUtil
+    {
+        private const string HtmlContentType = "text/html";
+
+        public static bool IsHtml(string contentType)
+        {
+            if (String.IsNullOrEmpty(contentType))
+            {
+                return false;
+            }
+
+            string[] parts = contentType.Split(';');
+
+            return String.Equals(parts[0].Trim(), HtmlContentType, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool IsHtml(string requestUrl, byte[] buffer, int offset, int count)
+        {
+            IntPtr realContentTypePtr = IntPtr.Zero;
+
+            try
+            {
+                if (offset != 0)
+                {
+                    byte[] originalBuffer = buffer;
+
+                    if (count > 512)
+                    {
+                        count = 512;
+                    }
+
+                    buffer = new byte[count];
+
+                    Array.Copy(originalBuffer, offset, buffer, 0, count);
+                }
+
+                int ret = NativeMethods.FindMimeFromData(IntPtr.Zero, requestUrl, buffer, buffer.Length, null, 0, out realContentTypePtr, 0);
+
+                if (ret == 0 && realContentTypePtr != IntPtr.Zero)
+                {
+                    return IsHtml(Marshal.PtrToStringUni(realContentTypePtr));
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            finally
+            {
+                if (realContentTypePtr != IntPtr.Zero)
+                {
+                    Marshal.FreeCoTaskMem(realContentTypePtr);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/DelayConnectingHttpSocketAdapter.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/DelayConnectingHttpSocketAdapter.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// This class wraps an IHttpSocketAdapter so that it does not connect
+    /// until the last possible moment, and it does not connect unless absolutely
+    /// necessary. This way, a connection can be initialized early, but there is
+    /// no performance hit unless the connection is used.
+    /// </summary>
+    /// <remarks>
+    /// Each method is implemented using one of two strategies:
+    /// 1. If a method is really using the connection (sending or receiving data),
+    ///    make sure the connection has been created and pass the call through.
+    /// 2. If a method is just initializing the connection (e.g. setting headers),
+    ///    pass the call through only if the connection already exists. Otherwise,
+    ///    store the call arguments and replay them after the connection is created.
+    /// </remarks>
+    internal class DelayConnectingHttpSocketAdapter : IHttpSocketAdapter
+    {
+        private Task<IHttpSocketAdapter> _connectedSocketTask = null;
+        private Func<Task<IHttpSocketAdapter>> _connectFunction;
+
+        private List<KeyValuePair<string, string>> _headers = new List<KeyValuePair<string, string>>();
+        private ResponseHandler _responseHandler = null;
+
+        internal DelayConnectingHttpSocketAdapter(Func<Task<IHttpSocketAdapter>> connectFunction)
+        {
+            _connectFunction = connectFunction;
+        }
+
+        void IHttpSocketAdapter.AddRequestHeader(string name, string value)
+        {
+            if (_connectedSocketTask != null)
+            {
+                _connectedSocketTask.Result.AddRequestHeader(name, value);
+            }
+            else
+            {
+                _headers.Add(new KeyValuePair<string, string>(name, value));
+            }
+        }
+
+        async Task IHttpSocketAdapter.CompleteRequest()
+        {
+            // If a connection hasn't been created yet, no data has been sent.
+            // If there's no response listener, no data will be received.
+            // If both of those are true, it's a safe bet that the connection is unnecessary.
+            if (_connectedSocketTask == null && _responseHandler == null)
+            {
+                return;
+            }
+            else
+            {
+                IHttpSocketAdapter socket = await GetConnectedSocketAsync();
+
+                await socket.CompleteRequest();
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            if (_connectedSocketTask != null)
+            {
+                _connectedSocketTask.Result.Dispose();
+                _connectedSocketTask = null;
+            }
+        }
+
+        async Task<string> IHttpSocketAdapter.GetResponseHeader(string headerName)
+        {
+            IHttpSocketAdapter socket = await GetConnectedSocketAsync();
+
+            return await socket.GetResponseHeader(headerName);
+        }
+
+        async Task<int> IHttpSocketAdapter.GetResponseStatusCode()
+        {
+            IHttpSocketAdapter socket = await GetConnectedSocketAsync();
+
+            return await socket.GetResponseStatusCode();
+        }
+
+        void IHttpSocketAdapter.SetResponseHandler(ResponseHandler handler)
+        {
+            if (_connectedSocketTask != null)
+            {
+                _connectedSocketTask.Result.SetResponseHandler(handler);
+            }
+            else
+            {
+                _responseHandler = handler;
+            }
+        }
+
+        async Task IHttpSocketAdapter.WaitForResponseComplete()
+        {
+            IHttpSocketAdapter socket = await GetConnectedSocketAsync();
+
+            await socket.WaitForResponseComplete();
+        }
+
+        async Task IHttpSocketAdapter.WriteToRequestAsync(byte[] buffer, int offset, int count)
+        {
+            IHttpSocketAdapter socket = await GetConnectedSocketAsync();
+
+            await socket.WriteToRequestAsync(buffer, offset, count);
+        }
+
+        private Task<IHttpSocketAdapter> GetConnectedSocketAsync()
+        {
+            if (_connectedSocketTask == null)
+            {
+                _connectedSocketTask = CreateSocketConnectionAsync();
+            }
+
+            return _connectedSocketTask;
+        }
+
+        private async Task<IHttpSocketAdapter> CreateSocketConnectionAsync()
+        {
+            IHttpSocketAdapter socket = await _connectFunction.Invoke();
+
+            if (socket == null)
+            {
+                // Failed to create the connection, so instead we create this null
+                // object to handle future requests with no-ops.
+                socket = new FailedConnectionHttpSocketAdapter();
+            }
+            else
+            {
+                if (_responseHandler != null)
+                {
+                    socket.SetResponseHandler(_responseHandler);
+                }
+
+                foreach (KeyValuePair<string, string> header in _headers)
+                {
+                    socket.AddRequestHeader(header.Key, header.Value);
+                }
+            }
+
+            return socket;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/FailedConnectionHttpSocketAdapter.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/FailedConnectionHttpSocketAdapter.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// Null-object implementation of a connection, which stands in for a connection
+    /// that could not be created.
+    /// </summary>
+    internal class FailedConnectionHttpSocketAdapter : IHttpSocketAdapter
+    {
+        void IHttpSocketAdapter.AddRequestHeader(string name, string value)
+        {
+        }
+
+        Task IHttpSocketAdapter.CompleteRequest()
+        {
+            return StaticTaskResult.Complete;
+        }
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        Task<string> IHttpSocketAdapter.GetResponseHeader(string headerName)
+        {
+            return StaticTaskResult.NullString;
+        }
+
+        Task<int> IHttpSocketAdapter.GetResponseStatusCode()
+        {
+            return StaticTaskResult.HttpInternalServerError;
+        }
+
+        void IHttpSocketAdapter.SetResponseHandler(ResponseHandler handler)
+        {
+        }
+
+        Task IHttpSocketAdapter.WaitForResponseComplete()
+        {
+            return StaticTaskResult.Complete;
+        }
+
+        Task IHttpSocketAdapter.WriteToRequestAsync(byte[] buffer, int offset, int count)
+        {
+            return StaticTaskResult.Complete;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/HostConnectionData.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/HostConnectionData.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// Represents an host connection published from a design tool's host process.
+    /// </summary>
+    internal class HostConnectionData
+    {
+        internal HostConnectionData(string connectionString, string sslConnectionString, string requestSignalName, string readySignalName, IEnumerable<string> projectPaths)
+        {
+            ConnectionString = connectionString;
+            SslConnectionString = sslConnectionString;
+            RequestSignalName = requestSignalName;
+            ReadySignalName = readySignalName;
+            ProjectPaths = projectPaths;
+        }
+
+        /// <summary>
+        /// The name of the event to signal when you want the host to start.
+        /// </summary>
+        public string RequestSignalName { get; private set; }
+
+        /// <summary>
+        /// The name of the event to wait on after requesting the host to start.
+        /// </summary>
+        public string ReadySignalName { get; private set; }
+
+        /// <summary>
+        /// The string used to identify the host connection.
+        /// </summary>
+        public string ConnectionString { get; private set; }
+
+        /// <summary>
+        /// The string used to identify the SSL host connection.
+        /// </summary>
+        public string SslConnectionString { get; private set; }
+
+        /// <summary>
+        /// The physical paths of projects loaded in this instance of the design tool.
+        /// </summary>
+        public IEnumerable<string> ProjectPaths { get; private set; }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/HostConnectionUtil.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/HostConnectionUtil.cs
@@ -1,0 +1,266 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    internal static class HostConnectionUtil
+    {
+        // The maximum amount of time we will wait for the host server to start.
+        // The actual time it takes should be significantly less than this.
+        private static readonly TimeSpan HostStartupTimeout = TimeSpan.FromMilliseconds(1500);
+
+        /// <summary>
+        /// Find the host connection for an ASP.NET application.
+        /// </summary>
+        /// <param name="applicationPhysicalPath">The physical root path of the application</param>
+        /// <param name="connection">The connection that is found.</param>
+        /// <returns>True if a connection is found for the given application.</returns>
+        internal static bool FindHostConnection(string applicationPhysicalPath, out HostConnectionData connection)
+        {
+            applicationPhysicalPath = PathUtil.NormalizeDirectoryPath(applicationPhysicalPath);
+
+            foreach (string instanceFileName in GetAllInstanceFileNames())
+            {
+                HostConnectionData connectionCandidate;
+
+                if (ReadConnectionData(instanceFileName, out connectionCandidate))
+                {
+                    if (ConnectionContainsApplication(connectionCandidate, applicationPhysicalPath))
+                    {
+                        connection = connectionCandidate;
+                        return true;
+                    }
+                }
+            }
+
+            connection = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Send a signal to the host to make sure the it is running.
+        /// </summary>
+        /// <param name="applicationPhysicalPath">The root path of this application</param>
+        /// <param name="blockUntilStarted">If true, this method will not return until the host signals that it is ready.</param>
+        /// <returns>True if the handle was successfully signaled, and the host server is ready</returns>
+        internal static bool SignalHostForStartup(string applicationPhysicalPath, bool blockUntilStarted)
+        {
+            HostConnectionData connection;
+
+            if (FindHostConnection(applicationPhysicalPath, out connection))
+            {
+                return SignalHostForStartup(connection, blockUntilStarted);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Send a signal to the host to make sure it is running.
+        /// </summary>
+        /// <param name="connection">The connection to signal.</param>
+        /// <returns>True if the handle was successfully signaled, and the host server is ready</returns>
+        internal static bool SignalHostForStartup(HostConnectionData connection)
+        {
+            return SignalHostForStartup(connection, blockUntilStarted: true);
+        }
+
+        /// <summary>
+        /// Send a signal to the host to make sure it is running.
+        /// </summary>
+        /// <param name="connection">The connection to signal.</param>
+        /// <param name="blockUntilStarted">If true, this method will not return until the host signals it is ready</param>
+        /// <returns>True if the handle was successfully signaled, and the host server is ready</returns>
+        internal static bool SignalHostForStartup(HostConnectionData connection, bool blockUntilStarted)
+        {
+            if (connection.RequestSignalName != null &&
+                connection.ReadySignalName != null)
+            {
+                SendSignal(connection.RequestSignalName);
+
+                if (blockUntilStarted)
+                {
+                    return WaitForSignal(connection.ReadySignalName);
+                }
+                else
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void SendSignal(string signalName)
+        {
+            EventWaitHandle signalHandle;
+
+            if (EventWaitHandle.TryOpenExisting(signalName, out signalHandle))
+            {
+                try
+                {
+                    signalHandle.Set();
+                }
+                finally
+                {
+                    signalHandle.Dispose();
+                }
+            }
+        }
+
+        private static bool WaitForSignal(string signalName)
+        {
+            EventWaitHandle signalHandle;
+
+            if (EventWaitHandle.TryOpenExisting(signalName, out signalHandle))
+            {
+                try
+                {
+                    return signalHandle.WaitOne(HostStartupTimeout);
+                }
+                finally
+                {
+                    signalHandle.Dispose();
+                }
+            }
+            else
+            {
+                // The ready signal is disposed after the host server is started,
+                // so if it does not exist, that means the server is already started.
+                return true;
+            }
+        }
+
+        private static bool ConnectionContainsApplication(HostConnectionData connection, string applicationPhysicalPath)
+        {
+            foreach (string projectPath in connection.ProjectPaths)
+            {
+                if (PathUtil.CompareNormalizedPaths(applicationPhysicalPath, projectPath))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<string> GetAllInstanceFileNames()
+        {
+            IEnumerable<string> fileNames = Enumerable.Empty<string>();
+
+            foreach (string indexFileName in BrowserLinkConstants.IndexFileNames)
+            {
+                fileNames = fileNames.Concat(ReadAllLinesFrom(indexFileName));
+            }
+
+            return fileNames;
+        }
+
+        private static bool ReadConnectionData(string instanceFileName, out HostConnectionData connection)
+        {
+            List<string> lines = ReadAllLinesFrom(instanceFileName);
+
+            if (lines.Count > 2)
+            {
+                string connectionString = lines[0];
+                string sslConnectionString = lines[1];
+                string requestSignalName = instanceFileName + BrowserLinkConstants.RequestSignalSuffix;
+                string readySignalName = instanceFileName + BrowserLinkConstants.ReadySignalSuffix;
+                List<string> projects = new List<string>();
+
+                for (int i = 2; i < lines.Count; i++)
+                {
+                    projects.Add(PathUtil.NormalizeDirectoryPath(lines[i]));
+                }
+
+                connection = new HostConnectionData(connectionString, sslConnectionString, requestSignalName, readySignalName, projects);
+                return true;
+            }
+
+            connection = null;
+            return false;
+        }
+
+        private static List<string> ReadAllLinesFrom(string fileName)
+        {
+            MemoryMappedFile file = null;
+            MemoryMappedViewStream stream = null;
+
+            if (MappedFileExists(fileName))
+            {
+                try
+                {
+                    file = MemoryMappedFile.OpenExisting(fileName, MemoryMappedFileRights.Read);
+
+                    stream = file.CreateViewStream(0, 0, MemoryMappedFileAccess.Read);
+
+                    return ReadAllLinesFrom(stream);
+                }
+                catch (FileNotFoundException)
+                {
+                    // File does not exist
+                }
+                finally
+                {
+                    if (stream != null)
+                    {
+                        stream.Dispose();
+                    }
+
+                    if (file != null)
+                    {
+                        file.Dispose();
+                    }
+                }
+            }
+
+            // Failure, return an empty set
+            return new List<string>();
+        }
+
+        private static List<string> ReadAllLinesFrom(MemoryMappedViewStream stream)
+        {
+            List<string> lines = new List<string>();
+
+            StreamReader reader = new StreamReader(stream, Encoding.UTF8);
+
+            // A value of 0 indicates the end of valid content in the file.
+            // reader.Peek() returns <0 when it reaches the end of the stream.
+            while (reader.Peek() > 0)
+            {
+                lines.Add(reader.ReadLine());
+            }
+
+            return lines;
+        }
+
+        /// <summary>
+        /// Use P/Invoke methods to check for the existance of the mapped file. This
+        /// is faster than letting MemoryMappedFile.OpenExisting fail, because that
+        /// method throws an exception.
+        /// </summary>
+        private static bool MappedFileExists(string fileName)
+        {
+            IntPtr handle = NativeMethods.OpenFileMapping(4 /* FILE_MAP_READ */, false, fileName);
+
+            if (handle == IntPtr.Zero)
+            {
+                return false;
+            }
+            else
+            {
+                NativeMethods.CloseHandle(handle);
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/HttpAdapterRequestStream.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/HttpAdapterRequestStream.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// This class wraps the output stream of an IHttpSocketAdapter into a Stream
+    /// interface, for use with System.IO.*Writer classes.
+    /// </summary>
+    internal class HttpAdapterRequestStream : Stream
+    {
+        private RevolvingBuffers<byte> _buffers = new RevolvingBuffers<byte>(1024);
+
+        internal HttpAdapterRequestStream(IHttpSocketAdapter adapter)
+        {
+            SendDataFromBuffersAsync(_buffers, adapter);
+        }
+
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override long Length
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+
+        public override void Flush()
+        {
+            var buffer = _buffers;
+            if (buffer != null)
+            {
+                _buffers = null;
+
+                buffer.WaitForBufferEmptyAsync().ContinueWith(task =>
+                {
+                    buffer.Dispose();
+                });
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _buffers.CopyDataToBuffer(buffer, offset, count);
+        }
+
+        /// <remarks>
+        /// This function is the pump that pushes data from the buffers into an
+        /// HTTP connection. It asynchronously waits on data, then asynchronously
+        /// waits while the data is sent, then waits on more data, etc.
+        /// </remarks>
+        private static async void SendDataFromBuffersAsync(RevolvingBuffers<byte> buffer, IHttpSocketAdapter adapter)
+        {
+            while (true)
+            {
+                ArraySegment<byte> bufferToSend = await buffer.GetBufferedDataAsync();
+                if (bufferToSend.Count == 0)
+                {
+                    break;
+                }
+
+                await adapter.WriteToRequestAsync(bufferToSend.Array, bufferToSend.Offset, bufferToSend.Count);
+            }
+
+            await adapter.CompleteRequest();
+
+            adapter.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/HttpSocketAdapter.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/HttpSocketAdapter.cs
@@ -1,0 +1,412 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    internal delegate Task ResponseHandler(byte[] buffer, int offset, int count);
+
+    /// <summary>
+    /// HttpSocketAdapter wraps an ISocketAdapter, and provides functionality
+    /// for making an HTTP request and handling an HTTP reponse on the socket.
+    /// </summary>
+    internal interface IHttpSocketAdapter : IDisposable
+    {
+        /// <summary>
+        /// Adds a header to the HTTP request. If this method is called after
+        /// the first call to WriteToRequestAsync, it is ignored.
+        /// </summary>
+        /// <param name="name">The name of the header</param>
+        /// <param name="value">The value of the header</param>
+        void AddRequestHeader(string name, string value);
+
+        /// <summary>
+        /// Sends some request data. Data is sent using chunked transfer-encoding,
+        /// so there can be multiple calls to this method.
+        /// </summary>
+        /// <param name="buffer">Buffer containing the data.</param>
+        /// <param name="offset">The position in the buffer where the data starts.</param>
+        /// <param name="count">The number of bytes of data in the buffer.</param>
+        /// <returns>A task that completes when the data has been sent.</returns>
+        Task WriteToRequestAsync(byte[] buffer, int offset, int count);
+
+        /// <summary>
+        /// Sends data signifying the end of the request. This should only be
+        /// called once. Any subsequent calls to WriteToRequestAsync will probably
+        /// be ignored by the server, and may result in exceptions if the socket
+        /// is closed.
+        /// </summary>
+        /// <returns>A task that completes when the data has been sent (not when the response is complete).</returns>
+        Task CompleteRequest();
+
+        /// <summary>
+        /// Gets the HTTP status code returned by the server.
+        /// </summary>
+        /// <returns>A task that completes when the status code has been returned by the server. The task returns the status code.</returns>
+        Task<int> GetResponseStatusCode();
+
+        /// <summary>
+        /// Gets the value of a header in the HTTP response from the server.
+        /// </summary>
+        /// <param name="headerName">The case-insensitive name of the header.</param>
+        /// <returns>A task that completes when all headers have been returned by the server. The task returns the value of the requested header.</returns>
+        Task<string> GetResponseHeader(string headerName);
+
+        /// <summary>
+        /// Sets a callback method that will be called with data contained in the
+        /// response body returned by the server.
+        /// </summary>
+        void SetResponseHandler(ResponseHandler handler);
+
+        /// <summary>
+        /// Wait until the response body has been completely returned by the server.
+        /// </summary>
+        /// <returns>A task that completes when the response body has been completely returned by the server.</returns>
+        Task WaitForResponseComplete();
+    }
+
+    internal class HttpSocketAdapter : IHttpSocketAdapter
+    {
+        private static readonly ArraySegment<byte> CrlfBuffer = CreateBufferContaining("\r\n", Encoding.ASCII);
+
+        private ISocketAdapter _socket;
+        private ResponseReader _responseReader;
+
+        private StringBuilder _headerSection = new StringBuilder();
+
+        public HttpSocketAdapter(string httpMethod, Uri url, ISocketAdapter socket)
+        {
+            _socket = socket;
+
+            string requestUri = url.GetComponents(UriComponents.PathAndQuery | UriComponents.Fragment, UriFormat.UriEscaped);
+
+            _headerSection.AppendFormat("{0} {1} HTTP/1.1\r\n", httpMethod, requestUri);
+
+            AddRequestHeader("Host", url.GetComponents(UriComponents.HostAndPort, UriFormat.UriEscaped));
+            AddRequestHeader("Transfer-Encoding", "chunked");
+            AddRequestHeader("Connection", "keep-alive");
+        }
+
+        public void Dispose()
+        {
+            if (_responseReader != null)
+            {
+                _responseReader.Stop();
+                _responseReader.Dispose();
+                _responseReader = null;
+            }
+
+            if (_socket != null)
+            {
+                _socket.Dispose();
+                _socket = null;
+            }
+        }
+
+        public static async Task<IHttpSocketAdapter> OpenHttpSocketAsync(string httpMethod, Uri url)
+        {
+            ISocketAdapter socket = await SocketAdapter.OpenSocketAsync(url);
+
+            if (socket != null)
+            {
+                return new HttpSocketAdapter(httpMethod, url, socket);
+            }
+
+            return null;
+        }
+
+        public void AddRequestHeader(string name, string value)
+        {
+            if (_headerSection != null)
+            {
+                _headerSection.AppendFormat("{0}: {1}\r\n", name, value);
+            }
+        }
+
+        public Task<int> GetResponseStatusCode()
+        {
+            return GetResponseReader().GetResponseStatusCode();
+        }
+
+        public async Task<string> GetResponseHeader(string headerName)
+        {
+            Dictionary<string, string> responseHeaders = await GetResponseReader().GetResponseHeaders();
+
+            foreach (KeyValuePair<string, string> responseHeader in responseHeaders)
+            {
+                if (responseHeader.Key.Equals(headerName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return responseHeader.Value;
+                }
+            }
+
+            return null;
+        }
+
+        public void SetResponseHandler(ResponseHandler handler)
+        {
+            GetResponseReader().SetResponseHandler(handler);
+        }
+
+        public Task WaitForResponseComplete()
+        {
+            return GetResponseReader().WaitForResponseComplete();
+        }
+
+        private static ArraySegment<byte> CreateBufferContaining(string text, Encoding encoding)
+        {
+            return new ArraySegment<byte>(encoding.GetBytes(text));
+        }
+
+        public Task WriteToRequestAsync(byte[] buffer, int offset, int count)
+        {
+            List<ArraySegment<byte>> bufferList = new List<ArraySegment<byte>>();
+
+            AddRequestBuffersIfNecessary(bufferList);
+
+            if (count > 0)
+            {
+                bufferList.Add(CreateBufferContaining(count.ToString("X"), Encoding.ASCII));
+                bufferList.Add(CrlfBuffer);
+                bufferList.Add(new ArraySegment<byte>(buffer, offset, count));
+                bufferList.Add(CrlfBuffer);
+            }
+
+            return _socket.SendAsync(bufferList);
+        }
+
+        public Task CompleteRequest()
+        {
+            List<ArraySegment<byte>> bufferList = new List<ArraySegment<byte>>();
+
+            AddRequestBuffersIfNecessary(bufferList);
+
+            bufferList.Add(CreateBufferContaining("0", Encoding.ASCII));
+            bufferList.Add(CrlfBuffer);
+            bufferList.Add(CrlfBuffer);
+
+            return _socket.SendAsync(bufferList);
+        }
+
+        private void AddRequestBuffersIfNecessary(List<ArraySegment<byte>> bufferList)
+        {
+            if (_headerSection != null)
+            {
+                bufferList.Add(CreateBufferContaining(_headerSection.ToString(), Encoding.ASCII));
+                bufferList.Add(CrlfBuffer);
+
+                _headerSection = null;
+            }
+        }
+
+        private ResponseReader GetResponseReader()
+        {
+            if (_responseReader == null)
+            {
+                _responseReader = new ResponseReader(_socket);
+            }
+
+            return _responseReader;
+        }
+
+        private class ResponseReader : IDisposable
+        {
+            private static readonly char[] StatusLineSeparators = new char[] { ' ' };
+            private static readonly char[] HeaderLineSeparators = new char[] { ':' };
+
+            private SocketReader _socketReader;
+
+            private CancellationTokenSource _cancelSource = new CancellationTokenSource();
+
+            private TaskCompletionSource<int> _statusCodeTask = new TaskCompletionSource<int>();
+            private TaskCompletionSource<Dictionary<string, string>> _responseHeadersTask = new TaskCompletionSource<Dictionary<string, string>>();
+            private TaskCompletionSource<ResponseHandler> _setResponseHandlerTask = new TaskCompletionSource<ResponseHandler>();
+
+            private Task _responseCompleteTask;
+
+            public ResponseReader(ISocketAdapter socket)
+            {
+                _socketReader = new SocketReader(socket);
+
+                _responseCompleteTask = ReadResponse();
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "_cancelSource",
+                Justification = "The CancellationTokenSource can't be disposed until _responseCompleteTask is done with it. But it will be disposed.")]
+            public void Dispose()
+            {
+                _responseCompleteTask.ContinueWith(completeTask =>
+                {
+                    _cancelSource.Dispose();
+                });
+            }
+
+            internal void Stop()
+            {
+                _cancelSource.Cancel();
+            }
+
+            internal Task<int> GetResponseStatusCode()
+            {
+                return _statusCodeTask.Task;
+            }
+
+            internal Task<Dictionary<string, string>> GetResponseHeaders()
+            {
+                return _responseHeadersTask.Task;
+            }
+
+            internal void SetResponseHandler(ResponseHandler handler)
+            {
+                _setResponseHandlerTask.SetResult(handler);
+            }
+
+            internal Task WaitForResponseComplete()
+            {
+                return _responseCompleteTask;
+            }
+
+            private string GetResponseHeader(string headerName)
+            {
+                foreach (KeyValuePair<string, string> responseHeader in GetResponseHeaders().Result)
+                {
+                    if (responseHeader.Key.Equals(headerName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return responseHeader.Value;
+                    }
+                }
+
+                return null;
+            }
+
+            private bool HasResponseHeader(string headerName, string headerValue)
+            {
+                string actualHeaderValue = GetResponseHeader(headerName);
+
+                if (actualHeaderValue == null)
+                {
+                    return false;
+                }
+
+                return String.Equals(headerValue, actualHeaderValue, StringComparison.OrdinalIgnoreCase);
+            }
+
+            private async Task ReadResponse()
+            {
+                try
+                {
+                    _statusCodeTask.SetResult(await ReadStatusLine());
+
+                    _responseHeadersTask.SetResult(await ReadHeaders());
+
+                    if (HasResponseHeader("Transfer-Encoding", "chunked"))
+                    {
+                        await ReadChunkedContent();
+                    }
+                    else
+                    {
+                        await ReadContent();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _statusCodeTask.TrySetException(ex);
+                    _responseHeadersTask.TrySetException(ex);
+
+                    throw;
+                }
+            }
+
+            private async Task<int> ReadStatusLine()
+            {
+                string statusLine = await _socketReader.ReadLine(_cancelSource.Token);
+
+                string[] parts = statusLine.Split(StatusLineSeparators, count: 3);
+
+                if (parts.Length >= 2)
+                {
+                    int statusCode;
+
+                    if (Int32.TryParse(parts[1], out statusCode))
+                    {
+                        return statusCode;
+                    }
+                }
+
+                // Status line was in an unexpected format. Assume "500: Internal Server Error"
+                return 500;
+            }
+
+            private async Task<Dictionary<string, string>> ReadHeaders()
+            {
+                Dictionary<string, string> responseHeaders = new Dictionary<string, string>();
+
+                while (true)
+                {
+                    string headerLine = await _socketReader.ReadLine(_cancelSource.Token);
+
+                    if (String.IsNullOrEmpty(headerLine))
+                    {
+                        // End of headers
+                        return responseHeaders;
+                    }
+
+                    string[] parts = headerLine.Split(HeaderLineSeparators, 2, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length == 2)
+                    {
+                        responseHeaders[parts[0]] = parts[1].Trim();
+                    }
+                }
+            }
+
+            private async Task ReadChunkedContent()
+            {
+                while (true)
+                {
+                    string contentLengthLine = await _socketReader.ReadLine(_cancelSource.Token);
+                    int contentLength = Int32.Parse(contentLengthLine, System.Globalization.NumberStyles.HexNumber);
+
+                    if (contentLength == 0)
+                    {
+                        return;
+                    }
+
+                    await ReadBytesIntoResponse(contentLength);
+
+                    await _socketReader.ReadLine(_cancelSource.Token);
+                }
+            }
+
+            private Task ReadContent()
+            {
+                string contentLengthString = GetResponseHeader("Content-Length");
+
+                if (String.IsNullOrEmpty(contentLengthString))
+                {
+                    return StaticTaskResult.Zero;
+                }
+
+                long contentLength;
+
+                if (!Int64.TryParse(contentLengthString, out contentLength))
+                {
+                    return StaticTaskResult.Zero;
+                }
+
+                return ReadBytesIntoResponse(contentLength);
+            }
+
+            private async Task ReadBytesIntoResponse(long bytesToRead)
+            {
+                ResponseHandler handler = await _setResponseHandlerTask.Task;
+
+                await _socketReader.ReadBytesIntoResponseHandler(bytesToRead, handler, _cancelSource.Token);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/MappingDataWriter.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/MappingDataWriter.cs
@@ -1,0 +1,120 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// This feature is provided for page renderers, so they can provide mapping
+    /// data as the page renders.
+    /// </summary>
+    internal class MappingDataWriter : IDisposable
+    {
+        private BinaryWriter _binaryWriter;
+        private bool _wroteAnyData = false;
+        
+        internal MappingDataWriter(IHttpSocketAdapter mappingDataSocket)
+        {
+            _binaryWriter = new BinaryWriter(new HttpAdapterRequestStream(mappingDataSocket));
+        }
+        
+        public void Dispose()
+        {
+            if (_binaryWriter != null)
+            {
+                _binaryWriter.Flush();
+                _binaryWriter.Dispose();
+                _binaryWriter = null;
+            }
+        }
+        
+        public void WriteBeginContext(int sourceStartPosition, int sourceLength, bool isLiteral, string sourceFilePath, int renderedOutputIndex, int renderedPosition)
+        {
+            WriteType(BrowserLinkConstants.MappingDataType.BeginContext);
+            
+            WriteValue(BrowserLinkConstants.MappingDataValue.SourceStartPosition, sourceStartPosition);
+            WriteValue(BrowserLinkConstants.MappingDataValue.SourceLength, sourceLength);
+            WriteValue(BrowserLinkConstants.MappingDataValue.IsLiteral, isLiteral);
+            WriteValue(BrowserLinkConstants.MappingDataValue.SourceFilePath, sourceFilePath);
+            WriteValue(BrowserLinkConstants.MappingDataValue.RenderedOutputIndex, renderedOutputIndex);
+            WriteValue(BrowserLinkConstants.MappingDataValue.RenderedPosition, renderedPosition);
+            
+            WriteEndOfDataBlock();
+        }
+        
+        public void WriteEndContext(int renderedOutputIndex, int renderedPosition)
+        {
+            WriteType(BrowserLinkConstants.MappingDataType.EndContext);
+            
+            WriteValue(BrowserLinkConstants.MappingDataValue.RenderedOutputIndex, renderedOutputIndex);
+            WriteValue(BrowserLinkConstants.MappingDataValue.RenderedPosition, renderedPosition);
+            
+            WriteEndOfDataBlock();
+        }
+        
+        public void WriteOutputDefinition(int renderedOutputIndex, string renderedContent)
+        {
+            WriteType(BrowserLinkConstants.MappingDataType.RenderedOutputDefinition);
+            
+            WriteValue(BrowserLinkConstants.MappingDataValue.RenderedOutputIndex, renderedOutputIndex);
+            WriteValue(BrowserLinkConstants.MappingDataValue.RenderedContent, renderedContent);
+            
+            WriteEndOfDataBlock();
+        }
+        
+        public void WriteTextRelationship(int parentRenderedOutputIndex, int childRenderedOutputIndex, int relativeRenderedPosition)
+        {
+            WriteType(BrowserLinkConstants.MappingDataType.RenderedOutputRelationship);
+            
+            WriteValue(BrowserLinkConstants.MappingDataValue.ParentRenderedOutputIndex, parentRenderedOutputIndex);
+            WriteValue(BrowserLinkConstants.MappingDataValue.ChildRenderedOutputIndex, childRenderedOutputIndex);
+            WriteValue(BrowserLinkConstants.MappingDataValue.RelativeRenderedPosition, relativeRenderedPosition);
+            
+            WriteEndOfDataBlock();
+        }
+        
+        public void WriteEndOfData()
+        {
+            if (_wroteAnyData)
+            {
+                WriteType(BrowserLinkConstants.MappingDataType.EndOfData);
+                WriteEndOfDataBlock();
+            }
+        }
+        
+        private void WriteType(BrowserLinkConstants.MappingDataType type)
+        {
+            _wroteAnyData = true;
+
+            _binaryWriter.Write((int)type);
+        }
+        
+        private void WriteValue(BrowserLinkConstants.MappingDataValue valueKey, int value)
+        {
+            _binaryWriter.Write((int)valueKey);
+            _binaryWriter.Write((int)BrowserLinkConstants.MappingDataValueType.Int32Value);
+            _binaryWriter.Write(value);
+        }
+        
+        private void WriteValue(BrowserLinkConstants.MappingDataValue valueKey, string value)
+        {
+            _binaryWriter.Write((int)valueKey);
+            _binaryWriter.Write((int)BrowserLinkConstants.MappingDataValueType.StringValue);
+            _binaryWriter.Write(value);
+        }
+        
+        private void WriteValue(BrowserLinkConstants.MappingDataValue valueKey, bool value)
+        {
+            _binaryWriter.Write((int)valueKey);
+            _binaryWriter.Write((int)BrowserLinkConstants.MappingDataValueType.BooleanValue);
+            _binaryWriter.Write(value);
+        }
+        
+        private void WriteEndOfDataBlock()
+        {
+            _binaryWriter.Write((int)BrowserLinkConstants.MappingDataValue.EndOfDataValues);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/Microsoft.VisualStudio.Web.BrowserLink.xproj
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/Microsoft.VisualStudio.Web.BrowserLink.xproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>616f445c-7a41-4e61-98e3-1b70d70f9f09</ProjectGuid>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <RootNamespace>Microsoft.VisualStudio.Web.BrowserLink</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/NativeMethods.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/NativeMethods.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    internal static class NativeMethods
+    {
+
+        [DllImport("urlmon.dll", CharSet = CharSet.Unicode, ExactSpelling = true, SetLastError = false)]
+        internal static extern int FindMimeFromData(
+            IntPtr pBC,
+            [MarshalAs(UnmanagedType.LPWStr)] string pwzUrl,
+            [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.I1, SizeParamIndex = 3)]
+            byte[] pBuffer,
+            int cbSize,
+            [MarshalAs(UnmanagedType.LPWStr)]  string pwzMimeProposed,
+            int dwMimeFlags,
+            out IntPtr ppwzMimeOut,
+            int dwReserved);
+
+
+        [DllImport("kernel32.dll", SetLastError = false, CharSet = CharSet.Unicode)]
+        internal static extern IntPtr OpenFileMapping(
+            uint dwDesiredAccess,
+            bool bInheritHandle,
+            string lpName);
+
+        [DllImport("kernel32.dll", SetLastError = false)]
+        internal static extern bool CloseHandle(
+            IntPtr hHandle);
+
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/PageExecutionContext.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/PageExecutionContext.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// A PageExecutionContext is created for each source file that is executed as
+    /// part of the page. It remembers the path to the source file and the TextWriter
+    /// being used, to pass on during BeginContext and EndContext calls.
+    /// </summary>
+    internal class PageExecutionContext
+    {
+        private string _sourceFilePath;
+        private TextWriterDecorator _writer;
+        private MappingDataWriter _mappingDataWriter;
+
+        public PageExecutionContext(MappingDataWriter mappingDataWriter, string sourceFilePath, TextWriter writer)
+        {
+            _mappingDataWriter = mappingDataWriter;
+            _sourceFilePath = sourceFilePath;
+            _writer = writer as TextWriterDecorator;
+        }
+
+        /// <summary>
+        /// Specifies the part of the source file that is currently being rendered.
+        /// </summary>
+        /// <param name="position">The start position of the range in the source file</param>
+        /// <param name="length">The length of the range in the source file</param>
+        /// <param name="isLiteral">True if the range is being written verbatim from the source file</param>
+        public void BeginContext(int position, int length, bool isLiteral)
+        {
+            try
+            { 
+                if (_writer != null)
+                {
+                    _mappingDataWriter.WriteBeginContext(position, length, isLiteral, _sourceFilePath, _writer.RenderedOutputIndex, _writer.OutputPosition);
+                }
+            }
+            catch
+            { }
+        }
+
+        /// <summary>
+        /// Specifies that we are done rendering the part of the source file from 
+        /// BeginContext. Begin/End context calls can be nested within the same file.
+        /// </summary>
+        public void EndContext()
+        {
+            try
+            {
+                if (_writer != null)
+                {
+                    _mappingDataWriter.WriteEndContext(_writer.RenderedOutputIndex, _writer.OutputPosition);
+                }
+            }
+            catch
+            { }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/PageExecutionListenerFeature.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/PageExecutionListenerFeature.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// This feature is provided for page renderers, so they can provide mapping
+    /// data as the page renders.
+    /// </summary>
+    internal class PageExecutionListenerFeature : IDisposable
+    {
+        private MappingDataWriter _mappingDataWriter;
+        private List<TextWriterDecorator> _writers = new List<TextWriterDecorator>();
+
+        internal PageExecutionListenerFeature(IHttpSocketAdapter mappingDataSocket)
+        {
+            _mappingDataWriter = new MappingDataWriter(mappingDataSocket);
+        }
+
+        /// <summary>
+        /// This method is called to give the listener a chance to replace the TextWriter
+        /// used to render the page.
+        /// </summary>
+        /// <param name="writer">The original TextWriter for the output stream</param>
+        /// <returns>A TextWriter that will be used for writing the output.</returns>
+        public TextWriter DecorateWriter(TextWriter writer)
+        {
+            try
+            { 
+                TextWriterDecorator decorator = new TextWriterDecorator(writer, this, _writers.Count);
+
+                foreach (TextWriterDecorator existingWriter in _writers)
+                {
+                    AddTextRelationship(existingWriter, decorator);
+                }
+
+                _writers.Add(decorator);
+
+                return decorator;
+            }
+            catch
+            {
+                return writer;
+            }
+        }
+
+        /// <summary>
+        /// Create a context that associates a TextWriter with a source file.
+        /// </summary>
+        /// <param name="sourceFilePath">The path to the source file.</param>
+        /// <param name="writer">The TextWriter used to render the source file</param>
+        /// <returns>A context that will be called back with mapping data within the source file.</returns>
+        public PageExecutionContext GetContext(string sourceFilePath, TextWriter writer)
+        {
+            return new PageExecutionContext(_mappingDataWriter, sourceFilePath, writer);
+        }
+
+        internal void AddTextRelationship(TextWriterDecorator copyingToWriter, TextWriterDecorator copyingFromWriter)
+        {
+            _mappingDataWriter.WriteTextRelationship(copyingToWriter.RenderedOutputIndex, copyingFromWriter.RenderedOutputIndex, copyingToWriter.OutputPosition);
+        }
+
+        public void Dispose()
+        {
+            if (_mappingDataWriter != null)
+            {
+                try
+                {
+                    SendEndOfData();
+
+                    _mappingDataWriter.Dispose();
+                }
+                catch { }
+                finally
+                {
+                    _mappingDataWriter = null;
+                }
+            }
+        }
+
+        private void SendEndOfData()
+        {
+            foreach (TextWriterDecorator writer in _writers)
+            {
+                _mappingDataWriter.WriteOutputDefinition(writer.RenderedOutputIndex, writer.RenderedOutput);
+            }
+
+            _mappingDataWriter.WriteEndOfData();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/PathUtil.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/PathUtil.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// Helpers for dealing with file paths
+    /// </summary>
+    internal static class PathUtil
+    {
+        /// <summary>
+        /// Takes a path, and returns an equivalent path in a format that can
+        /// be used for comparisons.
+        /// </summary>
+        public static string NormalizeDirectoryPath(string path)
+        {
+            if (path.Contains("/"))
+            {
+                path = path.Replace('/', '\\');
+            }
+
+            if (!path.EndsWith("\\"))
+            {
+                path += "\\";
+            }
+
+            return path.ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// Compares two paths, assuming they were both produced by NormalizeDirectoryPath
+        /// </summary>
+        /// <returns>True if the paths are equivalent</returns>
+        public static bool CompareNormalizedPaths(string path1, string path2)
+        {
+            return String.Equals(path1, path2, StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/Project.json
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/Project.json
@@ -1,0 +1,30 @@
+{
+  "version": "1.0.0-*",
+  "description": "A middleware that supports creating a communication channel between the development environment and one or more web browsers.",
+  "buildOptions": {
+    "warningsAsErrors": true,
+    "keyFile": "../../tools/Key.snk",
+    "xmlDoc": true,
+    "compile": {
+      "include": [
+        "**/*.cs"
+      ]
+    } 
+  },
+  "dependencies": {
+    "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0",
+    "Microsoft.AspNetCore.Http.Abstractions": "1.0.0",
+    "Microsoft.Extensions.FileProviders.Physical": "1.0.0"
+  },
+  "frameworks": {
+    "net451": {},
+    "netstandard1.5": {
+      "dependencies": {
+        "System.Net.Sockets": "4.1.0",
+        "System.Net.Primitives": "4.0.11",
+        "System.IO.MemoryMappedFiles": "4.0.0",
+        "System.Diagnostics.Tools": "4.0.1"
+      }
+    }
+  }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/RevolvingBuffers.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/RevolvingBuffers.cs
@@ -1,0 +1,358 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// A first-in-first-out data buffering system that reuses existing buffers
+    /// to minimize the amount of memory required.
+    /// </summary>
+    /// <typeparam name="DataType">The type of data being stored</typeparam>
+    internal sealed class RevolvingBuffers<DataType> : IDisposable
+    {
+        private int _defaultBufferSize;
+        private object _lockObject = new object();
+
+        private LinkedList<Buffer> _buffers = new LinkedList<Buffer>();
+        private LinkedListNode<Buffer> _currentInputBuffer;
+        private LinkedListNode<Buffer> _currentOutputBuffer;
+
+        private TaskCompletionSource<ArraySegment<DataType>> _getBufferedData = null;
+        private TaskCompletionSource<bool> _waitForBufferEmpty = null;
+
+        /// <summary>
+        /// Initialize the RevolvingBuffers
+        /// </summary>
+        /// <param name="defaultBufferSize">
+        /// The default size of an individual buffer. Larger buffers may be created
+        /// to accomodate larger sets of input data.
+        /// </param>
+        internal RevolvingBuffers(int defaultBufferSize)
+        {
+            _defaultBufferSize = defaultBufferSize;
+
+            _currentInputBuffer = _buffers.AddFirst(new Buffer(defaultBufferSize));
+        }
+
+        private Buffer InputBuffer
+        {
+            get { return _currentInputBuffer.Value; }
+        }
+
+        private Buffer OutputBuffer
+        {
+            get { return _currentOutputBuffer.Value; }
+        }
+
+        private bool HasAsyncReader
+        {
+            get { return _getBufferedData != null; }
+        }
+
+#if DEBUG
+        // FOR UNIT TESTING ONLY
+        internal int BufferCount
+        {
+            get { return _buffers.Count; }
+        }
+#endif
+
+        /// <summary>
+        /// Clear and free all the buffers. This also alerts asynchronous readers
+        /// that no more data is coming.
+        /// </summary>
+        public void Dispose()
+        {
+            lock (_lockObject)
+            {
+                GiveBufferToAsyncReader(default(ArraySegment<DataType>));
+
+                _buffers.Clear();
+                _currentOutputBuffer = null;
+                _currentInputBuffer = null;
+            }
+        }
+
+        /// <summary>
+        /// Copy data into the buffers.
+        /// </summary>
+        /// <param name="arraySegment">Segment of an array to copy</param>
+        public void CopyDataToBuffer(ArraySegment<DataType> arraySegment)
+        {
+            CopyDataToBuffer(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
+        }
+
+        /// <summary>
+        /// Copy data into the buffers.
+        /// </summary>
+        /// <param name="data">An array containing the data to copy</param>
+        /// <param name="offset">The starting index of the data to copy</param>
+        /// <param name="count">The number of data elements to copy</param>
+        public void CopyDataToBuffer(DataType[] data, int offset, int count)
+        {
+            lock (_lockObject)
+            {
+                EnsureSpaceInInputBuffer(count);
+
+                CopyDataToInputBuffer(data, offset, count);
+
+                if (HasAsyncReader && AdvanceToNextOutputBuffer())
+                {
+                    GiveBufferToAsyncReader(OutputBuffer.CreateArraySegment());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Synchronously reads data from the buffer.
+        /// </summary>
+        /// <returns>
+        /// An ArraySegment containing buffered data, or an empty buffer if there is no
+        /// data to read.
+        /// </returns>
+        /// <remarks>
+        /// The ArraySegment remains valid until GetBufferedData/Async is called again.
+        /// After the next call to this method, the buffer in the ArraySegment can be
+        /// reused for future data.
+        /// </remarks>
+        public ArraySegment<DataType> GetBufferedData()
+        {
+            lock (_lockObject)
+            {
+                if (AdvanceToNextOutputBuffer())
+                {
+                    return OutputBuffer.CreateArraySegment();
+                }
+                else
+                {
+                    SignalBufferEmpty();
+
+                    return default(ArraySegment<DataType>);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads data from the buffer.
+        /// </summary>
+        /// <returns>
+        /// A task that returns an ArraySegment containing buffered data. If there
+        /// is no buffered data, the task does not complete until more data is
+        /// buffered, or the buffers are disposed.
+        /// </returns>
+        /// <remarks>
+        /// The ArraySegment remains valid until GetBufferedData/Async is called again.
+        /// After the next call to this method, the buffer in the ArraySegment can be
+        /// reused for future data.
+        /// </remarks>
+        public Task<ArraySegment<DataType>> GetBufferedDataAsync()
+        {
+            lock (_lockObject)
+            {
+                if (AdvanceToNextOutputBuffer())
+                {
+                    return Task.FromResult(OutputBuffer.CreateArraySegment());
+                }
+                else
+                {
+                    _getBufferedData = new TaskCompletionSource<ArraySegment<DataType>>();
+
+                    // We need a local reference to the task here, because SignalBufferEmpty()
+                    // could end up calling Dispose(), and that will complete and then clear
+                    // _getBufferedData. We still want to return the completed task to the caller
+                    // of this method.
+                    Task<ArraySegment<DataType>> task = _getBufferedData.Task;
+
+                    SignalBufferEmpty();
+
+                    return task;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wait until all data has been read from the buffer.
+        /// </summary>
+        /// <returns>A task that completes when the last data has been read.</returns>
+        public Task WaitForBufferEmptyAsync()
+        {
+            lock (_lockObject)
+            {
+                if (_buffers.First.Value.DataCount == 0)
+                {
+                    return StaticTaskResult.True;
+                }
+
+                _waitForBufferEmpty = new TaskCompletionSource<bool>();
+
+                return _waitForBufferEmpty.Task;
+            }
+        }
+
+        private void CopyDataToInputBuffer(DataType[] data, int offset, int count)
+        {
+            Array.Copy(data, offset, InputBuffer.Data, InputBuffer.DataCount, count);
+
+            InputBuffer.DataCount += count;
+        }
+
+        private void EnsureSpaceInInputBuffer(int requiredCount)
+        {
+            if (InputBuffer.AvailableCount < requiredCount)
+            {
+                AdvanceToNextInputBuffer(requiredCount);
+            }
+        }
+
+        private bool AdvanceToNextInputBuffer(int requiredCount = 0)
+        {
+            LinkedListNode<Buffer> nextEmptyBuffer = GetNextEmptyInputBuffer(_currentInputBuffer);
+
+            if (nextEmptyBuffer == null)
+            {
+                nextEmptyBuffer = _buffers.AddLast(CreateNewBuffer(requiredCount));
+            }
+            else if (nextEmptyBuffer.Value.AvailableCount < requiredCount)
+            {
+                nextEmptyBuffer = _buffers.AddBefore(nextEmptyBuffer, CreateNewBuffer(requiredCount));
+            }
+
+            if (_currentInputBuffer != nextEmptyBuffer)
+            {
+                _currentInputBuffer = nextEmptyBuffer;
+
+                // Buffer was advanced
+                return true;
+            }
+            else
+            {
+                // Buffer did not change
+                return false;
+            }
+        }
+
+        private LinkedListNode<Buffer> GetNextEmptyInputBuffer(LinkedListNode<Buffer> currentBuffer)
+        {
+            if (!currentBuffer.Value.HasAnyData)
+            {
+                return currentBuffer;
+            }
+            else
+            {
+                return currentBuffer.Next;
+            }
+        }
+
+        private Buffer CreateNewBuffer(int requiredCount)
+        {
+            int bufferSize = _defaultBufferSize;
+
+            while (bufferSize < requiredCount)
+            {
+                bufferSize = bufferSize * 2;
+            }
+
+            return new Buffer(bufferSize);
+        }
+
+        private bool AdvanceToNextOutputBuffer()
+        {
+            RecycleCurrentOutputBuffer();
+
+            // Output buffer is always first in the list
+            _currentOutputBuffer = _buffers.First;
+
+            if (_currentOutputBuffer == _currentInputBuffer)
+            {
+                if (!AdvanceToNextInputBuffer())
+                {
+                    _currentOutputBuffer = null;
+                }
+            }
+
+            return _currentOutputBuffer != null;
+        }
+
+        private void RecycleCurrentOutputBuffer()
+        {
+            if (_currentOutputBuffer != null)
+            {
+                _currentOutputBuffer.Value.DataCount = 0;
+
+                // The buffer is moved to the end of the list, putting it in line
+                // as a potential input buffer
+                _buffers.AddLast(_currentOutputBuffer.Value);
+                _buffers.Remove(_currentOutputBuffer);
+            }
+        }
+        
+        private void GiveBufferToAsyncReader(ArraySegment<DataType> buffer)
+        {
+            if (_getBufferedData != null)
+            {
+                // _getBufferedData must be set to null before calling TrySetResult. The
+                // handler will likely try to read more data immediately, which will set
+                // a new _getBufferedData. If we clear _getBufferedData after TrySetResult,
+                // that will erase the new _getBufferedData instead of the old one.
+                TaskCompletionSource<ArraySegment<DataType>> tcs = _getBufferedData;
+                _getBufferedData = null;
+
+                tcs.TrySetResult(buffer);
+            }
+        }
+
+        private void SignalBufferEmpty()
+        {
+            if (_waitForBufferEmpty != null)
+            {
+                // _waitForBufferEmpty must be set to null before calling TrySetResult. It
+                // is unlikely that the handler would call WaitForBufferEmpty again, but if
+                // they do, and we clear _waitForBufferEmpty after TrySetResult, that will
+                // erase the new _waitForBufferEmpty instead of the old one.
+                TaskCompletionSource<bool> tcs = _waitForBufferEmpty;
+                _waitForBufferEmpty = null;
+
+                tcs.TrySetResult(true);
+            }
+        }
+
+        private class Buffer
+        {
+            internal Buffer(int size)
+            {
+                Data = new DataType[size];
+            }
+
+            public DataType[] Data
+            {
+                get;
+                private set;
+            }
+
+            public int DataCount
+            {
+                get;
+                set;
+            }
+
+            public int AvailableCount
+            {
+                get { return Data.Length - DataCount; }
+            }
+
+            public bool HasAnyData
+            {
+                get { return DataCount > 0; }
+            }
+
+            public ArraySegment<DataType> CreateArraySegment()
+            {
+                return new ArraySegment<DataType>(Data, 0, DataCount);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/ScriptInjectionFilterContext.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/ScriptInjectionFilterContext.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.IO;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// IScriptInjectionFilterContext is an abstraction of the request data required
+    /// by ScriptInjectionFilterStream. It is needed for unit testing, and eventually
+    /// so ASP.NET and ProjectK can share filter code even though they have different
+    /// HttpContext classes.
+    /// </summary>
+    internal interface IScriptInjectionFilterContext
+    {
+        /// <summary>
+        /// The local (app-relative) path of the request.
+        /// </summary>
+        string RequestPath { get; }
+
+        /// <summary>
+        /// The response body, where filtered content will be written.
+        /// </summary>
+        Stream ResponseBody { get; }
+
+        /// <summary>
+        /// The Content-Type that is being returned with the response.
+        /// </summary>
+        string ResponseContentType { get; }
+    }
+
+    internal class ScriptInjectionFilterContext : IScriptInjectionFilterContext
+    {
+        private HttpContext _httpContext;
+
+        internal ScriptInjectionFilterContext(HttpContext httpContext)
+        {
+            _httpContext = httpContext;
+        }
+
+        public string RequestPath
+        {
+            get
+            {
+                return _httpContext.Request.Path.HasValue
+                    ? _httpContext.Request.Path.ToString()
+                    : null;
+            }
+        }
+
+        public Stream ResponseBody
+        {
+            get { return _httpContext.Response.Body; }
+        }
+
+        public string ResponseContentType
+        {
+            get { return _httpContext.Response.ContentType; }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/ScriptInjectionFilterStream.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/ScriptInjectionFilterStream.cs
@@ -1,0 +1,295 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// This stream implementation is a passthrough filter. It's job is to add
+    /// links to the Browser Link connection scripts at the end of HTML content.
+    /// 
+    /// It does this using a connection to the host, where the actual filtering
+    /// work is done. If anything goes wrong with the host connection, or
+    /// if the content being written is not actually HTML, then the filter goes
+    /// into passthrough mode and returns all content to the output stream unchanged.
+    /// </summary>
+    internal class ScriptInjectionFilterStream : Stream
+    {
+        private enum FilterState
+        {
+            NothingSentToFilter,
+            ContentSentToFilter,
+            Passthrough,
+        }
+
+        private IHttpSocketAdapter _injectScriptSocket;
+        private IScriptInjectionFilterContext _context;
+        private Stream _outputStream;
+
+        private FilterState _filterState = FilterState.NothingSentToFilter;
+
+        internal ScriptInjectionFilterStream(IHttpSocketAdapter injectScriptSocket, IScriptInjectionFilterContext context)
+        {
+            _context = context;
+            _outputStream = _context.ResponseBody;
+            _injectScriptSocket = injectScriptSocket;
+
+            _injectScriptSocket.SetResponseHandler(CreateResponseHandler(_outputStream));
+        }
+
+        /// <summary>
+        /// Returns true if the filter is in Passthrough mode. All writes will
+        /// be passed to the output stream unmodified.
+        /// </summary>
+        public bool IsPassthrough
+        {
+            get { return _filterState == FilterState.Passthrough; }
+        }
+
+        /// <summary>
+        /// Returns true if any data has been sent to the host. At this point,
+        /// the filter cannot go into passthrough mode to handle a failure, because
+        /// the data that was sent to the host is lost.
+        /// </summary>
+        public bool SentContentToFilter
+        {
+            get { return _filterState == FilterState.ContentSentToFilter; }
+        }
+
+        /// <summary>
+        /// Returns true if the initial request to the host timed out without
+        /// returning a response code. 
+        /// </summary>
+        public bool ScriptInjectionTimedOut
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// Call this method to signal the host that all the content for filtering
+        /// has been sent, and then wait for the host to return the filtered content.
+        /// </summary>
+        /// <returns>A task that completes when the host has returned the filtered contet.</returns>
+        public async Task WaitForFilterComplete()
+        {
+            if (SentContentToFilter)
+            {
+                await _injectScriptSocket.CompleteRequest();
+
+                await _injectScriptSocket.WaitForResponseComplete();
+            }
+
+            CloseInjectScriptSocketAndBecomePassthrough();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            CloseInjectScriptSocketAndBecomePassthrough();
+        }
+
+        public override bool CanRead
+        {
+            get { return false; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return false; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return true; }
+        }
+
+        public override long Length
+        {
+            get { throw new NotSupportedException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+
+        public override void Flush()
+        {
+            Task.WaitAll(FlushAsync());
+        }
+
+        /// <remarks>
+        /// In order to flush the content to the output stream, we need to wait
+        /// for the content that was sent to the host to return. Once that
+        /// is done, the connection to the host is closed, and the stream
+        /// goes into passthrough mode. So effectively, any writes that come
+        /// after a call to flush will not be filtered.
+        /// </remarks>
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            await WaitForFilterComplete();
+
+            await _outputStream.FlushAsync();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            Task.WaitAll(WriteAsync(buffer, offset, count));
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            bool firstWrite = (_filterState == FilterState.NothingSentToFilter);
+
+            if (firstWrite)
+            {
+                DetermineIfFilterShouldBePassthrough(buffer, offset, count);
+
+                AddResponseHeadersToFilterRequest();
+            }
+
+            if (IsPassthrough)
+            {
+                return WriteToOutputStreamAsync(buffer, offset, count, ref cancellationToken);
+            }
+            else
+            {
+                _filterState = FilterState.ContentSentToFilter;
+
+                return WriteToInjectScriptSocketAsync(firstWrite, buffer, offset, count, cancellationToken);
+            }
+        }
+
+        private Task WriteToOutputStreamAsync(byte[] buffer, int offset, int count, ref CancellationToken cancellationToken)
+        {
+            return _outputStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        private Task WriteToInjectScriptSocketAsync(bool firstWrite, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (firstWrite)
+            {
+                return FirstWriteToInjectScriptSocketAsync(buffer, offset, count, cancellationToken);
+            }
+            else
+            {
+                return _injectScriptSocket.WriteToRequestAsync(buffer, offset, count);
+            }
+        }
+
+        private async Task FirstWriteToInjectScriptSocketAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _injectScriptSocket.WriteToRequestAsync(buffer, offset, count);
+
+                Task<int> statusCodeTask = _injectScriptSocket.GetResponseStatusCode();
+
+                int statusCode = await TaskHelpers.WaitWithTimeout(
+                    statusCodeTask,
+                    timeout: TimeSpan.FromMilliseconds(1000),
+                    resultIfTimedOut: 504 /*Gateway Timeout*/);
+
+                if (statusCode == 200)
+                {
+                    return;
+                }
+
+                if (statusCode == 504)
+                {
+                    ScriptInjectionTimedOut = true;
+                }
+            }
+            catch
+            {
+                // Fall through to error case
+            }
+
+            // If the initial send fails, we can switch to passthrough mode
+            // and retry this write. Browser Link won't work, but at least
+            // the page will be returned to the browser.
+            CloseInjectScriptSocketAndBecomePassthrough();
+
+            await WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        private static ResponseHandler CreateResponseHandler(Stream outputStream)
+        {
+            // The host will send a well-known preamble before sending response data.
+            // The purpose is just to get the headers back before processing starts.
+            // The preamble should be skipped.
+
+            bool skippedFilterPreamble = false;
+
+            return async delegate (byte[] buffer, int offset, int count)
+            {
+                if (!skippedFilterPreamble)
+                {
+                    offset += BrowserLinkConstants.FilterPreamble.Length;
+                    count -= BrowserLinkConstants.FilterPreamble.Length;
+
+                    skippedFilterPreamble = true;
+                }
+
+                if (count > 0)
+                {
+                    await outputStream.WriteAsync(buffer, offset, count);
+                }
+            };
+        }
+
+        private void AddResponseHeadersToFilterRequest()
+        {
+            if (!IsPassthrough)
+            {
+                _injectScriptSocket.AddRequestHeader("Content-Type", _context.ResponseContentType);
+            }
+        }
+
+        private void DetermineIfFilterShouldBePassthrough(byte[] buffer, int offset, int count)
+        {
+            string contentTypeFromHeader = _context.ResponseContentType;
+            string path = _context.RequestPath;
+
+            if (!ContentTypeUtil.IsHtml(contentTypeFromHeader))
+            {
+                CloseInjectScriptSocketAndBecomePassthrough();
+            }
+            else if (!ContentTypeUtil.IsHtml(path, buffer, offset, count))
+            {
+                CloseInjectScriptSocketAndBecomePassthrough();
+            }
+        }
+
+        private void CloseInjectScriptSocketAndBecomePassthrough()
+        {
+            if (_injectScriptSocket != null)
+            {
+                _injectScriptSocket.Dispose();
+                _injectScriptSocket = null;
+            }
+
+            _filterState = FilterState.Passthrough;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/SocketAdapter.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/SocketAdapter.cs
@@ -1,0 +1,197 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// SocketAdapter wraps a System.Net.Socket, and provides Task-based async
+    /// methods for interacting with the Socket. It also provides an abstraction
+    /// layer for unit tests, so that they don't have to work with real sockets.
+    /// </summary>
+    internal interface ISocketAdapter : IDisposable
+    {
+        Task<int> ReceiveAsync(byte[] buffer, int offset, int count);
+
+        Task SendAsync(IList<ArraySegment<byte>> buffers);
+    }
+
+    internal class SocketAdapter : ISocketAdapter
+    {
+        private Socket _socket;
+        private SocketAsyncEventArgs _sendEventArgs = new SocketAsyncEventArgs();
+        private SocketAsyncEventArgs _receiveEventArgs = new SocketAsyncEventArgs();
+
+        public SocketAdapter(Socket socket)
+        {
+            _socket = socket;
+
+            _sendEventArgs.Completed += OnAsyncComplete;
+            _receiveEventArgs.Completed += OnAsyncComplete;
+        }
+
+        internal static async Task<ISocketAdapter> OpenSocketAsync(Uri url)
+        {
+            try
+            {
+                Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.IP);
+
+                SocketAdapter adapter = new SocketAdapter(socket);
+
+                await adapter.ConnectAsync(url);
+
+                return adapter;
+            }
+            catch
+            {
+                // Handle any socket error and return null
+            }
+
+            return null;
+        }
+
+        public void Dispose()
+        {
+            if (_socket != null)
+            {
+                _socket.Dispose();
+                _socket = null;
+            }
+
+            if (_sendEventArgs != null)
+            {
+                _sendEventArgs.Completed -= OnAsyncComplete;
+
+                _sendEventArgs.Dispose();
+                _sendEventArgs = null;
+            }
+
+            if (_receiveEventArgs != null)
+            {
+                _receiveEventArgs.Completed -= OnAsyncComplete;
+
+                _receiveEventArgs.Dispose();
+                _receiveEventArgs = null;
+            }
+        }
+
+        private Task ConnectAsync(Uri url)
+        {
+            TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
+
+            try
+            {
+                _sendEventArgs.UserToken = tcs;
+                _sendEventArgs.RemoteEndPoint = new DnsEndPoint(url.Host, url.Port);
+
+                _socket.ConnectAsync(_sendEventArgs);
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+
+            return tcs.Task;
+        }
+
+        public Task<int> ReceiveAsync(byte[] buffer, int offset, int count)
+        {
+            TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
+
+            if (_receiveEventArgs.UserToken != null)
+            {
+                // UserToken is set with a TCS whenever a receive is in progress, and is
+                // cleared as soon as the send is complete. Do not allow two receive
+                // operations at the same time.
+                tcs.SetException(new InvalidOperationException("Attempted to read data when a read was already in progress."));
+            }
+            else
+            {
+                try
+                {
+                    _receiveEventArgs.SetBuffer(buffer, offset, count);
+                    _receiveEventArgs.UserToken = tcs;
+
+                    _socket.ReceiveAsync(_receiveEventArgs);
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            }
+
+            return tcs.Task;
+        }
+
+        public Task SendAsync(IList<ArraySegment<byte>> buffers)
+        {
+            TaskCompletionSource<int> tcs = new TaskCompletionSource<int>();
+
+            if (_sendEventArgs.UserToken != null)
+            {
+                // UserToken is set with a TCS whenever a send is in progress, and is
+                // cleared as soon as the send is complete. Do not allow two send
+                // operations at the same time.
+                tcs.SetException(new InvalidOperationException("Attempted to send data when a send was already in progress."));
+            }
+            else
+            {
+                try
+                {
+                    if (buffers.Count > 0)
+                    {
+                        _sendEventArgs.BufferList = buffers;
+                        _sendEventArgs.UserToken = tcs;
+
+                        _socket.SendAsync(_sendEventArgs);
+                    }
+                    else
+                    {
+                        tcs.SetResult(0);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    tcs.SetException(ex);
+                }
+            }
+
+            return tcs.Task;
+        }
+
+        private static void OnAsyncComplete(object sender, SocketAsyncEventArgs e)
+        {
+            TaskCompletionSource<int> tcs = e.UserToken as TaskCompletionSource<int>;
+
+            // Clear this immediately! When the result is set on the TCS, it could
+            // trigger more send or receive requests, and they will fail if it looks
+            // like a request is still in progress.
+            e.UserToken = null;
+
+            try
+            {
+                if (e.SocketError == SocketError.OperationAborted)
+                {
+                    tcs.SetResult(0);
+                }
+                else if (e.SocketError != SocketError.Success)
+                {
+                    tcs.SetException(new SocketException((int)e.SocketError));
+                }
+                else
+                {
+                    tcs.SetResult(e.BytesTransferred);
+                }
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/SocketReader.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/SocketReader.cs
@@ -1,0 +1,244 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// This is a helper class for reading data from a Socket. It encapsulates
+    /// the ability to alternately read decoded characters and lines, or raw
+    /// data, from the same data source.
+    /// </summary>
+    internal class SocketReader
+    {
+        private ISocketAdapter _socket;
+        private DecoderAdapter _decoderAdapter = new DecoderAdapter();
+
+        private byte[] _buffer = new byte[10240];
+        private int _bufferCurrentPosition = 0;
+        private int _bufferStopPosition = 0;
+
+        internal SocketReader(ISocketAdapter socket)
+        {
+            _socket = socket;
+        }
+
+        /// <summary>
+        /// Sets the Encoding that will be used for ReadChar and ReadLine.
+        /// </summary>
+        public void SetEncoding(Encoding encoding)
+        {
+            _decoderAdapter.SetDecoder(encoding.GetDecoder());
+        }
+
+        /// <summary>
+        /// Read characters from the socket until a CRLF is encountered.
+        /// </summary>
+        /// <returns>
+        /// A task that completes when enough data has been returned by the server.
+        /// The task returns the text of the line, excluding the CRLF.
+        /// </returns>
+        public async Task<string> ReadLine(CancellationToken cancellationToken)
+        {
+            StringBuilder line = new StringBuilder();
+
+            bool foundCr = false;
+
+            while (true)
+            {
+                char character = await ReadChar(cancellationToken);
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                if (character == '\r')
+                {
+                    if (!foundCr)
+                    {
+                        foundCr = true;
+
+                        continue;
+                    }
+                }
+                else if (foundCr)
+                {
+                    if (character == '\n')
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        foundCr = false;
+
+                        line.Append('\r');
+                    }
+                }
+
+                line.Append(character);
+            }
+
+            return line.ToString();
+        }
+
+        /// <summary>
+        /// Read a single character from the socket.
+        /// </summary>
+        /// <returns>A task that completes when enough data has been returned from the server.</returns>
+        public async Task<char> ReadChar(CancellationToken cancellationToken)
+        {
+            char result;
+
+            while (!DecodeChar(out result))
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                await ReceiveMoreBytes(cancellationToken);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Reads some raw data into a ResponseHandler method.
+        /// </summary>
+        /// <returns>
+        /// A task that completes when enough data has been returned by the server.
+        /// The task returns the number of bytes sent to the ResponseHandler.
+        /// </returns>
+        public async Task<int> ReadBytesIntoResponseHandler(long totalBytesToRead, ResponseHandler handler, CancellationToken cancellationToken)
+        {
+            long totalBytesRead = 0;
+
+            while (totalBytesToRead > 0)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                int bytesRemainingInBuffer = _bufferStopPosition - _bufferCurrentPosition;
+
+                if (bytesRemainingInBuffer == 0)
+                {
+                    await ReceiveMoreBytes(cancellationToken);
+
+                    bytesRemainingInBuffer = _bufferStopPosition - _bufferCurrentPosition;
+                }
+
+                int bytesToRead;
+                if (totalBytesToRead < bytesRemainingInBuffer)
+                {
+                    // This cast is safe because totalBytesToRead < bytesRemainingInBuffer,
+                    // and bytesRemainingInBuffer is an int.
+                    bytesToRead = (int)totalBytesToRead;
+                }
+                else
+                {
+                    bytesToRead = bytesRemainingInBuffer;
+                }
+
+                await handler.Invoke(_buffer, _bufferCurrentPosition, bytesToRead);
+
+                _bufferCurrentPosition += bytesToRead;
+                totalBytesRead += bytesToRead;
+                totalBytesToRead -= bytesToRead;
+            }
+
+            return (int)totalBytesRead;
+        }
+
+        private async Task<bool> ReceiveMoreBytes(CancellationToken cancellationToken)
+        {
+            int bytesRemainingInBuffer = _bufferStopPosition - _bufferCurrentPosition;
+            int bytesReceived = 0;
+
+            if (bytesRemainingInBuffer > 0)
+            {
+                Array.Copy(_buffer, _bufferCurrentPosition, _buffer, 0, bytesRemainingInBuffer);
+
+                _bufferCurrentPosition = 0;
+                _bufferStopPosition = bytesRemainingInBuffer;
+            }
+
+            int spaceInBuffer = _buffer.Length - bytesRemainingInBuffer;
+
+            if (spaceInBuffer > 0)
+            {
+                bytesReceived = await TaskHelpers.WaitWithCancellation(
+                    _socket.ReceiveAsync(_buffer, bytesRemainingInBuffer, spaceInBuffer),
+                    cancellationToken, 0);
+
+                _bufferCurrentPosition = 0;
+                _bufferStopPosition = bytesRemainingInBuffer + bytesReceived;
+            }
+
+            return bytesReceived > 0;
+        }
+
+        private bool DecodeChar(out char result)
+        {
+            return _decoderAdapter.DecodeCharacter(_buffer, ref _bufferCurrentPosition, _bufferStopPosition - _bufferCurrentPosition, out result);
+        }
+
+        /// <summary>
+        /// This helper class maintains state used in decoding characters
+        /// that may be multi-byte, when all the bytes might not be returned
+        /// by the server at the same time (or they might fall on the edge of
+        /// the buffer used to read data from the server).
+        /// </summary>
+        private class DecoderAdapter
+        {
+            private Decoder _decoder = Encoding.ASCII.GetDecoder();
+
+            private char[] characterBuffer = new char[1];
+
+            public void SetDecoder(Decoder decoder)
+            {
+                _decoder = decoder;
+            }
+
+            public bool DecodeCharacter(byte[] buffer, ref int bufferPosition, int bufferBytes, out char result)
+            {
+                if (bufferBytes >= 1)
+                {
+                    int bytesToUse = 1;
+                    int charactersReturned = 0;
+
+                    while (bytesToUse < bufferBytes)
+                    {
+                        charactersReturned = _decoder.GetCharCount(buffer, bufferPosition, bytesToUse);
+
+                        if (charactersReturned == 1)
+                        {
+                            break;
+                        }
+
+                        bytesToUse++;
+                    }
+
+                    charactersReturned = _decoder.GetChars(buffer, bufferPosition, bytesToUse, characterBuffer, 0);
+
+                    bufferPosition += bytesToUse;
+
+                    if (charactersReturned == 1)
+                    {
+                        result = characterBuffer[0];
+                        return true;
+                    }
+                }
+
+                result = '\0';
+                return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/StaticTaskResult.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/StaticTaskResult.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    internal static class StaticTaskResult
+    {
+        public static readonly Task<bool> True = Task.FromResult(true);
+        public static readonly Task<bool> False = Task.FromResult(false);
+        public static readonly Task<string> NullString = Task.FromResult((string)null);
+        public static readonly Task Complete = True;
+
+        public static readonly Task<int> HttpInternalServerError = Task.FromResult(500);
+
+        public static readonly Task<int> Zero = Task.FromResult(0);
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/TaskHelpers.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/TaskHelpers.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    internal static class TaskHelpers
+    {
+        /// <summary>
+        /// Add a timeout to a task. If the timeout expires before the underlying
+        /// task completes, the wrapper task returns a fixed value.
+        /// </summary>
+        /// <param name="task">The task being awaited</param>
+        /// <param name="timeout">The amount of time to wait</param>
+        /// <param name="resultIfTimedOut">The result returned if the timeout expires</param>
+        /// <remarks>
+        /// The <paramref name="task"/> will continue to execute after the 
+        /// <paramref name="timeout"/> expires, but tasks awaiting the wrapper will
+        /// be unblocked.
+        /// </remarks>
+        public static async Task<ResultType> WaitWithTimeout<ResultType>(Task<ResultType> task, TimeSpan timeout, ResultType resultIfTimedOut)
+        {
+            CancellationTokenSource cancelTimeout = new CancellationTokenSource();
+
+            Task<ResultType> timeoutTask = Task.Delay(timeout, cancelTimeout.Token).ContinueWith(x => resultIfTimedOut);
+
+            Task<ResultType> completedTask = await Task.WhenAny(task, timeoutTask);
+
+            cancelTimeout.Cancel();
+
+            return completedTask.Result;
+        }
+
+        /// <summary>
+        /// Wrap a task so that it can be cancelled. If the task is cancelled before
+        /// the underlying task completes, the wrapper task returns a fixed value.
+        /// </summary>
+        /// <param name="task">The task being awaited</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="resultIfCancelled">The result returned if the timeout expires</param>
+        /// <returns>A task that can be cancelled before it completes</returns>
+        /// <remarks>
+        /// The <paramref name="task"/> will continue to execute after the
+        /// <paramref name="cancellationToken"/> is set, but tasks awaiting the
+        /// wrapper will be unblocked.
+        /// </remarks>
+        public static async Task<ResultType> WaitWithCancellation<ResultType>(Task<ResultType> task, CancellationToken cancellationToken, ResultType resultIfCancelled)
+        {
+            TaskCompletionSource<ResultType> cancelTcs = new TaskCompletionSource<ResultType>();
+
+            cancellationToken.Register(delegate ()
+            {
+                cancelTcs.TrySetResult(resultIfCancelled);
+            });
+
+            return await await Task.WhenAny(task, cancelTcs.Task);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.BrowserLink/TextWriterDecorator.cs
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink/TextWriterDecorator.cs
@@ -1,0 +1,344 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// A wrapper for a TextWriter that allows us to record mapping information
+    /// as content is written to the output.
+    /// </summary>
+    internal class TextWriterDecorator : TextWriter
+    {
+        private TextWriter _decoratedWriter;
+        private StringWriter _bufferWriter;
+        private PageExecutionListenerFeature _listener;
+
+        internal TextWriterDecorator(TextWriter decoratedWriter, PageExecutionListenerFeature listener, int renderdOutputIndex)
+        {
+            _decoratedWriter = decoratedWriter;
+            _listener = listener;
+
+            _bufferWriter = new StringWriter(_decoratedWriter.FormatProvider);
+            _bufferWriter.NewLine = _decoratedWriter.NewLine;
+
+            RenderedOutputIndex = renderdOutputIndex;
+        }
+
+        /// <summary>
+        /// Returns the current character position where output is being written.
+        /// </summary>
+        internal int OutputPosition
+        {
+            get { return _bufferWriter.GetStringBuilder().Length; }
+        }
+
+        /// <summary>
+        /// An ID used to identify this writer withing the current page request.
+        /// </summary>
+        internal int RenderedOutputIndex
+        {
+            get;
+            private set;
+        }
+
+        /// <summary>
+        /// The complete content that has been written to this writer.
+        /// </summary>
+        internal string RenderedOutput
+        {
+            get { return _bufferWriter.GetStringBuilder().ToString(); }
+        }
+
+        #region TextWriter implementation
+        // All TextWriter method implementations need to, at a minimum, pass exactly
+        // the same method call to the decorated writer. Then they can do optional
+        // recording operations. Usually this means writing the same data to a
+        // second writer to remember what was written.
+
+        public override Encoding Encoding
+        {
+            get { return _decoratedWriter.Encoding; }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _decoratedWriter.Dispose();
+
+                _bufferWriter.Dispose();
+            }
+        }
+
+        public override void Flush()
+        {
+            _decoratedWriter.Flush();
+        }
+
+        public override Task FlushAsync()
+        {
+            return _decoratedWriter.FlushAsync();
+        }
+
+        public override IFormatProvider FormatProvider
+        {
+            get { return _decoratedWriter.FormatProvider; }
+        }
+
+        public override string NewLine
+        {
+            get { return _decoratedWriter.NewLine; }
+
+            set
+            {
+                _decoratedWriter.NewLine = value;
+
+                _bufferWriter.NewLine = value;
+            }
+        }
+
+        public override void Write(char value)
+        {
+            _decoratedWriter.Write(value);
+
+            _bufferWriter.Write(value);
+        }
+
+        public override void Write(bool value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override void Write(char[] buffer)
+        {
+            _bufferWriter.Write(buffer);
+
+            _decoratedWriter.Write(buffer);
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            _bufferWriter.Write(buffer, index, count);
+
+            _decoratedWriter.Write(buffer, index, count);
+        }
+
+        public override void Write(decimal value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override void Write(double value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override void Write(float value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override void Write(int value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override void Write(long value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override void Write(object value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override void Write(string value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override void Write(uint value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override void Write(ulong value)
+        {
+            _bufferWriter.Write(value);
+
+            _decoratedWriter.Write(value);
+        }
+
+        public override Task WriteAsync(char value)
+        {
+            _bufferWriter.Write(value);
+
+            return _decoratedWriter.WriteAsync(value);
+        }
+
+        public override Task WriteAsync(char[] buffer, int index, int count)
+        {
+            _bufferWriter.Write(buffer, index, count);
+
+            return _decoratedWriter.WriteAsync(buffer, index, count);
+        }
+
+        public override Task WriteAsync(string value)
+        {
+            _bufferWriter.Write(value);
+
+            return _decoratedWriter.WriteAsync(value);
+        }
+
+        public override void WriteLine()
+        {
+            _bufferWriter.WriteLine();
+
+            _decoratedWriter.WriteLine();
+        }
+
+        public override void WriteLine(bool value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(char value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(char[] buffer)
+        {
+            _bufferWriter.WriteLine(buffer);
+
+            _decoratedWriter.WriteLine(buffer);
+        }
+
+        public override void WriteLine(char[] buffer, int index, int count)
+        {
+            _bufferWriter.WriteLine(buffer, index, count);
+
+            _decoratedWriter.WriteLine(buffer, index, count);
+        }
+
+        public override void WriteLine(decimal value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(double value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(float value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(int value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(long value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(object value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(string value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(uint value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override void WriteLine(ulong value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            _decoratedWriter.WriteLine(value);
+        }
+
+        public override Task WriteLineAsync()
+        {
+            _bufferWriter.WriteLine();
+
+            return _decoratedWriter.WriteLineAsync();
+        }
+
+        public override Task WriteLineAsync(char value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            return _decoratedWriter.WriteLineAsync(value);
+        }
+
+        public override Task WriteLineAsync(char[] buffer, int index, int count)
+        {
+            _bufferWriter.WriteLine(buffer, index, count);
+
+            return _decoratedWriter.WriteLineAsync(buffer, index, count);
+        }
+
+        public override Task WriteLineAsync(string value)
+        {
+            _bufferWriter.WriteLine(value);
+
+            return _decoratedWriter.WriteLineAsync(value);
+        }
+        #endregion
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/AssertWithMessage.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/AssertWithMessage.cs
@@ -1,0 +1,36 @@
+﻿using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    /// <summary>
+    /// These wrappers accept useful messages about Assert failures, but I'm
+    /// not sure how to output them to Xunit.
+    /// </summary>
+    internal static class AssertWithMessage
+    {
+        public static void Equal(string expected, string actual, string messageFormat, params object[] messageArgs)
+        {
+            Assert.Equal(expected, actual);
+        }
+
+        public static void Equal(int expected, int actual, string messageFormat, params object[] messageArgs)
+        {
+            Assert.Equal(expected, actual);
+        }
+
+        public static void Equal(bool expected, bool actual, string messageFormat, params object[] messageArgs)
+        {
+            Assert.Equal(expected, actual);
+        }
+
+        public static void Null(object @object, string messageFormat, params object[] messageArgs)
+        {
+            Assert.Null(@object);
+        }
+
+        public static void NotNull(object @object, string messageFormat, params object[] messageArgs)
+        {
+            Assert.NotNull(@object);
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/ContentTypeUtilTest.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/ContentTypeUtilTest.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    public class ContentTypeUtilTest
+    {
+        [Fact]
+        public void IsHtml_DetectsTextHtmlInContentType()
+        {
+            string[] htmlContentTypes = new string[]
+            {
+                "text/html",
+                "TEXT/hTmL",
+                "text/html; charset=utf-8",
+                "text/html; any parameter",
+            };
+
+            string[] nonHtmlContentTypes = new string[]
+            {
+                "text/htmlx",
+                "text/html charset=utf-8",
+                null,
+                "",
+                "text/htm",
+            };
+
+            foreach (string htmlContentType in htmlContentTypes)
+            {
+                Assert.True(ContentTypeUtil.IsHtml(htmlContentType), htmlContentType);
+            }
+
+            foreach (string nonHtmlContentType in nonHtmlContentTypes)
+            {
+                Assert.False(ContentTypeUtil.IsHtml(nonHtmlContentType), nonHtmlContentType);
+            }
+        }
+
+        [Fact]
+        public void IsHtml_DetectsHtmlInBuffer()
+        {
+            // Arrange
+            byte[] buffer = Encoding.ASCII.GetBytes("<html><head></head><body></body></html>");
+
+            // Act
+            bool result = ContentTypeUtil.IsHtml("default.html",  buffer, 0, buffer.Length);
+
+            // Assert
+            Assert.Equal(true, result);
+        }
+
+        [Fact]
+        public void IsHtml_DetectsNonHtmlInBuffer()
+        {
+            // Arrange
+            byte[] buffer = Encoding.ASCII.GetBytes("var j = 10;");
+
+            // Act
+            bool result = ContentTypeUtil.IsHtml("default.html", buffer, 0, buffer.Length);
+
+            // Assert
+            Assert.Equal(false, result);
+        }
+
+        [Fact]
+        public void IsHtml_DetectsHtmlInBufferWithOffset()
+        {
+            // Arrange
+            byte[] buffer = Encoding.ASCII.GetBytes("<html><head></head><body></body></html>");
+            byte[] bufferWithLeadingBytes = new byte[100 + buffer.Length];
+
+            Array.Copy(buffer, 0, bufferWithLeadingBytes, 100, buffer.Length);
+
+            // Act
+            bool result = ContentTypeUtil.IsHtml("default.html", bufferWithLeadingBytes, 100, buffer.Length);
+
+            // Assert
+            Assert.Equal(true, result);
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/DelayConnectingHttpSocketAdapterTest.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/DelayConnectingHttpSocketAdapterTest.cs
@@ -1,0 +1,362 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    public class DelayConnectingHttpSocketAdapterTest
+    {
+        private MockHttpSocketAdapter _createdAdapter = null;
+        private string _responseContent = String.Empty;
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_CompleteRequest_DoesNotConnectIfNoDataAndNoResponse()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(DoNotConnect);
+
+            // Act
+            Task result = delayAdapter.CompleteRequest();
+
+            // Assert
+            TaskAssert.Completed(result, "CompleteRequest should complete immediately when there is no request.");
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_CompleteRequest_CompletesIfThereIsAResponseHandler()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            delayAdapter.SetResponseHandler(HandleAsciiResponse);
+
+            // Act
+            Task result = delayAdapter.CompleteRequest();
+
+            // Assert
+            Assert.True(_createdAdapter != null, "Adapter should have been created");
+            Assert.True(_createdAdapter.IsCompleted, "Adapter should be completed");
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_CompleteRequest_DoesNotRecreateConnection()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            byte[] bytesToWrite = Encoding.ASCII.GetBytes("Hello");
+            delayAdapter.WriteToRequestAsync(bytesToWrite, 0, bytesToWrite.Length);
+
+            // Act
+            delayAdapter.CompleteRequest();
+
+            // Assert
+            Assert.True(_createdAdapter != null, "Adapter was not created.");
+            Assert.True(_createdAdapter.IsCompleted, "Adapter was not Completed.");
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_WriteToRequestAsync_ConnectsAndWritesData()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            byte[] bytesToWrite = Encoding.ASCII.GetBytes("Hello, world!");
+
+            // Act
+            Task result = delayAdapter.WriteToRequestAsync(bytesToWrite, 7, 5);
+
+            // Assert
+            Assert.True(result != null, "No Task was returned.");
+            Assert.True(_createdAdapter != null, "Adapter was not created.");
+            Assert.Equal("world", _createdAdapter.RequestContent);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_WriteToRequestAsync_DoesNothingAfterFailureToConnect()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(FailToConnect);
+
+            byte[] bytesToWrite = Encoding.ASCII.GetBytes("Hello, world!");
+
+            // Act
+            Task result = delayAdapter.WriteToRequestAsync(bytesToWrite, 7, 5);
+
+            // Assert
+            TaskAssert.Completed(result);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_WriteToRequestAsync_DoesNotAttemptToConnectAfterFailure()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(FailToConnect);
+
+            byte[] bytesToWrite = Encoding.ASCII.GetBytes("Hello, world!");
+            delayAdapter.WriteToRequestAsync(bytesToWrite, 7, 5);
+
+            // Act
+            Task result = delayAdapter.WriteToRequestAsync(bytesToWrite, 7, 5);
+
+            // Assert
+            //  If we got here, a second connection was not attempted
+            TaskAssert.Completed(result);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_WriteToRequestAsync_WritesDataToSameConnection()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            byte[] bytesToWrite = Encoding.ASCII.GetBytes("Hello, world!");
+            delayAdapter.WriteToRequestAsync(bytesToWrite, 0, 7);
+
+            // Act
+            delayAdapter.WriteToRequestAsync(bytesToWrite, 7, 5);
+
+            // Assert
+            Assert.True(_createdAdapter != null, "Adapter was not created.");
+            Assert.Equal("Hello, world", _createdAdapter.RequestContent);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_GetResponseStatusCode_ConnectsAndRequestsStatusCode()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            // Act
+            Task<int> result = delayAdapter.GetResponseStatusCode();
+
+            // Assert
+            Assert.True(_createdAdapter != null, "Adapter was not created.");
+            TaskAssert.NotCompleted(result, "Status code should not be returned yet.");
+
+            // Act
+            _createdAdapter.SendResponseStatusCode(304);
+
+            // Assert
+            TaskAssert.ResultEquals(result, 304);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_GetResponseHeader_ConnectsAndGetsHeader()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            // Act
+            Task<string> result = delayAdapter.GetResponseHeader("Content-Length");
+
+            // Assert
+            Assert.True(_createdAdapter != null, "Adapter was not created.");
+            TaskAssert.NotCompleted(result, "Status code should not be returned yet.");
+
+            // Act
+            _createdAdapter.SendResponseHeader("Content-Length", "1234");
+
+            // Assert
+            TaskAssert.ResultEquals(result, "1234");
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_WaitForResponseComplete_ConnectsAndWaits()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            // Act
+            Task result = delayAdapter.WaitForResponseComplete();
+
+            // Assert
+            Assert.True(_createdAdapter != null, "Adapter was not created.");
+            TaskAssert.NotCompleted(result, "Status code should not be returned yet.");
+
+            // Act
+            _createdAdapter.SendResponseComplete();
+
+            // Assert
+            TaskAssert.Completed(result);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_AddRequestHeader_DoesNotConnect()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(DoNotConnect);
+
+            // Act
+            delayAdapter.AddRequestHeader("Hello", "World");
+
+            // Assert
+            //   If we got here, the connection was not created
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_AddRequestHeader_AddsHeadersAfterConnection()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            delayAdapter.AddRequestHeader("Hello", "World");
+            delayAdapter.AddRequestHeader("Hello2", "Planet");
+
+            // Act
+            delayAdapter.WaitForResponseComplete();
+
+            // Assert
+            Assert.True(_createdAdapter.RequestHeaders.ContainsKey("Hello"), "Header 'Hello' should be added.");
+            Assert.Equal("World", _createdAdapter.RequestHeaders["Hello"]);
+            Assert.True(_createdAdapter.RequestHeaders.ContainsKey("Hello2"), "Header 'Hello2' should be added.");
+            Assert.Equal("Planet", _createdAdapter.RequestHeaders["Hello2"]);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_AddRequestHeader_AddsHeadersToExistingConnection()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            delayAdapter.GetResponseStatusCode();
+
+            // Act
+            delayAdapter.AddRequestHeader("Hello", "World");
+
+            // Assert
+            Assert.True(_createdAdapter.RequestHeaders.ContainsKey("Hello"), "Header 'Hello' should be added.");
+            Assert.Equal("World", _createdAdapter.RequestHeaders["Hello"]);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_SetResponseHandler_DoesNotConnect()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(DoNotConnect);
+
+            // Act
+            delayAdapter.SetResponseHandler(HandleAsciiResponse);
+
+            // Assert
+            //   If we got here, the connection was not created
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_SetResponseHandler_SetsHandlerOnConnection()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            delayAdapter.SetResponseHandler(HandleAsciiResponse);
+
+            // Act
+            delayAdapter.WaitForResponseComplete();
+
+            // Assert
+            Assert.True(_createdAdapter.HasResponseHandler, "Response handler was not set.");
+
+            // Act
+            _createdAdapter.SendResponseBodyContent("This is a test", Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("This is a test", _responseContent);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_SetResponseHandler_SetsHandlerOnExistingConnection()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            delayAdapter.GetResponseStatusCode();
+
+            // Act
+            delayAdapter.SetResponseHandler(HandleAsciiResponse);
+
+            // Assert
+            Assert.True(_createdAdapter.HasResponseHandler, "Response handler was not set.");
+
+            // Act
+            _createdAdapter.SendResponseBodyContent("This is a test", Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("This is a test", _responseContent);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_Dispose_DisposesExistingConnection()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            delayAdapter.WaitForResponseComplete();
+
+            // Act
+            delayAdapter.Dispose();
+
+            // Assert
+            Assert.True(_createdAdapter.IsDisposed);
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_Dispose_DoesNothingIfNotConnected()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            // Act
+            delayAdapter.Dispose();
+
+            // Assert
+            //   Should do nothing
+        }
+
+        [Fact]
+        public void DelayConnectingHttpSocketAdapter_Dispose_DoesNotDisposeASecondTime()
+        {
+            // Arrange
+            IHttpSocketAdapter delayAdapter = new DelayConnectingHttpSocketAdapter(ConnectOnlyOnce);
+
+            delayAdapter.CompleteRequest();
+            delayAdapter.Dispose();
+
+            // Act
+            delayAdapter.Dispose();
+
+            // Assert
+            //   If we got here, the adapter was not Disposed a second time
+        }
+
+        private Task<IHttpSocketAdapter> ConnectOnlyOnce()
+        {
+            Assert.True(_createdAdapter == null, "A second connection is being created.");
+
+            return Task.FromResult<IHttpSocketAdapter>(_createdAdapter = new MockHttpSocketAdapter());
+        }
+
+        private static Task<IHttpSocketAdapter> DoNotConnect()
+        {
+            Assert.True(false, "IHttpSocketAdapter should not be created.");
+
+            return null;
+        }
+
+        private Task<IHttpSocketAdapter> FailToConnect()
+        {
+            Assert.True(_createdAdapter == null, "Attempted to create an adapter after a previous attempt failed.");
+
+            _createdAdapter = new MockHttpSocketAdapter();
+
+            return null;
+        }
+
+        private Task HandleAsciiResponse(byte[] buffer, int offset, int count)
+        {
+            _responseContent += Encoding.ASCII.GetString(buffer, offset, count);
+
+            return StaticTaskResult.True;
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/HttpSocketAdapterTest.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/HttpSocketAdapterTest.cs
@@ -1,0 +1,328 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    public class HttpSocketAdapterTest
+    {
+        [Fact]
+        public void HttpSocketAdapter_WritesRequestLineAndHeaders()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://localhost:1234/Hello.aspx?Name=%22Value%22#Fragment"), serverSocket);
+
+            // Act
+            clientSocket.CompleteRequest();
+
+            // Assert
+            Assert.StartsWith("GET /Hello.aspx?Name=%22Value%22#Fragment HTTP/1.1\r\n", serverSocket.SentContent);
+            Assert.Contains("Host: localhost:1234\r\n", serverSocket.SentContent);
+            Assert.Contains("Transfer-Encoding: chunked\r\n", serverSocket.SentContent);
+            Assert.EndsWith("\r\n\r\n0\r\n\r\n", serverSocket.SentContent);
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_AddsCustomHeaders()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("POST", new Uri("http://bing.com"), serverSocket);
+
+            // Act
+            clientSocket.AddRequestHeader("Content-Encoding", "UTF-16");
+            clientSocket.CompleteRequest();
+
+            // Assert
+            Assert.StartsWith("POST / HTTP/1.1\r\n", serverSocket.SentContent);
+            Assert.Contains("Host: bing.com:80\r\n", serverSocket.SentContent);
+            Assert.Contains("Transfer-Encoding: chunked\r\n", serverSocket.SentContent);
+            Assert.Contains("Content-Encoding: UTF-16\r\n", serverSocket.SentContent);
+            Assert.EndsWith("\r\n\r\n0\r\n\r\n", serverSocket.SentContent);
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_WritesChunkedContent()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("POST", new Uri("http://bing.com"), serverSocket);
+
+            byte[] buffer = Encoding.ASCII.GetBytes("First content, Second content.");
+
+            // Act
+            clientSocket.WriteToRequestAsync(buffer, 0, 14);
+
+            // Assert
+            Assert.EndsWith("\r\n\r\nE\r\nFirst content,\r\n", serverSocket.SentContent);
+
+            // Act
+            clientSocket.WriteToRequestAsync(buffer, 14, 16);
+
+            // Assert
+            Assert.EndsWith("\r\n\r\nE\r\nFirst content,\r\n10\r\n Second content.\r\n", serverSocket.SentContent);
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_GetResponseStatusCode_ReturnsStatusCode()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://bing.com"), serverSocket);
+
+            // Act
+            Task<int> result = clientSocket.GetResponseStatusCode();
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Before status line was sent.");
+
+            // Act
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.ResultEquals(result, 200, "After status line was sent.");
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_GetResponseStatusCode_MalformedStatusLine()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("Hello\r\n", Encoding.ASCII);
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://bing.com"), serverSocket);
+
+            // Act
+            Task<int> result = clientSocket.GetResponseStatusCode();
+
+            // Assert
+            TaskAssert.ResultEquals(result, 500);
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_GetResponseStatusCode_SocketException()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://bing.com"), serverSocket);
+
+            Task<int> responseCodeTask = clientSocket.GetResponseStatusCode();
+            Task<string> responseHeaderTask = clientSocket.GetResponseHeader("test header");
+            Task responseCompleteTask = clientSocket.WaitForResponseComplete();
+
+            // Act
+            serverSocket.ThrowExceptionFromReceiveAsync();
+
+            // Assert
+            TaskAssert.Faulted(responseCodeTask, "GetResponseStatusCode should have failed.");
+            TaskAssert.Faulted(responseHeaderTask, "GetResponseHeader should have failed.");
+            TaskAssert.Faulted(responseCompleteTask, "WaitForResponseComplete should have failed.");
+
+            AssertWithMessage.Equal("An error occurred.", responseCodeTask.Exception.InnerException.Message, "Wrong exception for GetResponseStatusCode");
+            AssertWithMessage.Equal("An error occurred.", responseHeaderTask.Exception.InnerException.Message, "Wrong exception for GetResponseHeader");
+            AssertWithMessage.Equal("An error occurred.", responseCompleteTask.Exception.InnerException.Message, "Wrong exception for WaitForResponseComplete");
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_GetResponseStatusCode_MalformedStatusCode()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("HTTP/1.1 NOTANUMBER OK\r\n", Encoding.ASCII);
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://bing.com"), serverSocket);
+
+            // Act
+            Task<int> result = clientSocket.GetResponseStatusCode();
+
+            // Assert
+            TaskAssert.ResultEquals(result, 500);
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_GetResponseHeader_ReturnsHeaderWhenAvailable()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://bing.com"), serverSocket);
+
+            // Act
+            Task<string> result = clientSocket.GetResponseHeader("content-encoding");
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Before header sent");
+
+            // Act
+            serverSocket.SendString("Content-Encoding: UTF-16\r\n", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Header values should not be returned until all headers are read.");
+
+            // Act - Blank newline means end of headers
+            serverSocket.SendString("Content-Length: 45\r\n\r\n", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.ResultEquals(result, "UTF-16");
+
+            // Act
+            Task<string> result2 = clientSocket.GetResponseHeader("content-length");
+
+            // Assert
+            TaskAssert.ResultEquals(result2, "45");
+
+            // Act
+            Task<string> result3 = clientSocket.GetResponseHeader("user-agent");
+
+            // Assert
+            TaskAssert.ResultEquals(result3, null);
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_GetResponseHeader_SocketException()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://bing.com"), serverSocket);
+
+            Task<int> responseCodeTask = clientSocket.GetResponseStatusCode();
+            Task<string> responseHeaderTask = clientSocket.GetResponseHeader("test header");
+            Task responseCompleteTask = clientSocket.WaitForResponseComplete();
+
+            TaskAssert.Completed(responseCodeTask, "GetResponseStatusCode should have failed.");
+            AssertWithMessage.Equal(200, responseCodeTask.Result, "Wrong result for GetResponseStatusCode");
+
+            // Act
+            serverSocket.ThrowExceptionFromReceiveAsync();
+
+            // Assert
+            TaskAssert.Faulted(responseHeaderTask, "GetResponseHeader should have failed.");
+            TaskAssert.Faulted(responseCompleteTask, "WaitForResponseComplete should have failed.");
+
+            AssertWithMessage.Equal("An error occurred.", responseHeaderTask.Exception.InnerException.Message, "Wrong exception for GetResponseHeader");
+            AssertWithMessage.Equal("An error occurred.", responseCompleteTask.Exception.InnerException.Message, "Wrong exception for WaitForResponseComplete");
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_ReadsContentIntoResponseHandler()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+            serverSocket.SendString("Content-Length: 40\r\n\r\n", Encoding.ASCII);
+            serverSocket.SendString("1234567890", Encoding.Unicode);
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://bing.com"), serverSocket);
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.Unicode);
+
+            // Act
+            clientSocket.SetResponseHandler(handler.HandlerMethod);
+
+            // Assert
+            Assert.Equal("1234567890", handler.Response);
+
+            // Act
+            Task responseComplete = clientSocket.WaitForResponseComplete();
+
+            // Assert
+            TaskAssert.NotCompleted(responseComplete, "After sending first chunk of data");
+
+            // Act - Send too much data to complete Content-Length
+            serverSocket.SendString("abcdefghijklmnopqrstuvwxyz", Encoding.Unicode);
+
+            // Assert - Only Content-Length was read
+            Assert.Equal("1234567890abcdefghij", handler.Response);
+            TaskAssert.Completed(responseComplete, "After sending remaining data");
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_ReadsChunkedContentIntoResponseHandler()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+            serverSocket.SendString("Transfer-Encoding: chunked\r\n\r\n", Encoding.ASCII);
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://bing.com"), serverSocket);
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.ASCII);
+
+            // Act
+            clientSocket.SetResponseHandler(handler.HandlerMethod);
+
+            // Assert
+            Assert.Equal("", handler.Response);
+
+            // Act
+            serverSocket.SendString("C\r\nHello, world\r\n", Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("Hello, world", handler.Response);
+
+            // Act
+            Task responseComplete = clientSocket.WaitForResponseComplete();
+
+            // Assert
+            TaskAssert.NotCompleted(responseComplete, "After sending 'Hello, World'");
+
+            // Act
+            serverSocket.SendString("8\r\nwide", Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("Hello, worldwide", handler.Response);
+            TaskAssert.NotCompleted(responseComplete, "After sending 'wide'");
+
+            // Act
+            serverSocket.SendString("!!\r\n", Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("Hello, worldwide!!\r\n", handler.Response);
+            TaskAssert.NotCompleted(responseComplete, "after sending '!!\r\n'");
+
+            // Act
+            serverSocket.SendString("\r\n", Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("Hello, worldwide!!\r\n", handler.Response);
+            TaskAssert.NotCompleted(responseComplete, "after sending '\r\n'");
+
+            // Act
+            serverSocket.SendString("0\r\n", Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("Hello, worldwide!!\r\n", handler.Response);
+            TaskAssert.Completed(responseComplete, "after completing the response");
+        }
+
+        [Fact]
+        public void HttpSocketAdapter_ThrowsExceptionForMalformedChunkedResponse()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+            serverSocket.SendString("Transfer-Encoding: chunked\r\n\r\n", Encoding.ASCII);
+
+            HttpSocketAdapter clientSocket = new HttpSocketAdapter("GET", new Uri("http://bing.com"), serverSocket);
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.ASCII);
+            clientSocket.SetResponseHandler(handler.HandlerMethod);
+
+            // Act
+            serverSocket.SendString("Hi!\r\n", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.Faulted(clientSocket.WaitForResponseComplete(), "ResponseReader should throw an exception if the response is malformed. Otherwise, the response will be blank and there will be nothing pointing to why it happened.");
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/Microsoft.VisualStudio.Web.BrowserLink.Test.xproj
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/Microsoft.VisualStudio.Web.BrowserLink.Test.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>96146399-2c42-4caa-abcd-cf1e0f000cec</ProjectGuid>
+    <RootNamespace>Microsoft.VisualStudio.Web.BrowserLink.Test</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/MockHttpSocketAdapter.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/MockHttpSocketAdapter.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    internal class MockHttpSocketAdapter : IHttpSocketAdapter
+    {
+        private Dictionary<string, TaskCompletionSource<string>> _responseHeaderRequests = new Dictionary<string, TaskCompletionSource<string>>();
+        private TaskCompletionSource<int> _statusCodeTask = new TaskCompletionSource<int>();
+        private TaskCompletionSource<object> _responseCompleteTask = new TaskCompletionSource<object>();
+
+        public Dictionary<string, string> RequestHeaders = new Dictionary<string, string>();
+        private ResponseHandler _responseHandler;
+
+        private StringBuilder _requestContent = new StringBuilder();
+
+        public void SendResponseStatusCode(int statusCode)
+        {
+            TaskAssert.NotCompleted(_statusCodeTask.Task, "MockHttpSocketAdapter: Response Status Code can only be set once.");
+
+            _statusCodeTask.SetResult(statusCode);
+        }
+
+        public void SendResponseHeader(string name, string value)
+        {
+            TaskCompletionSource<string> tcs;
+
+            if (!_responseHeaderRequests.TryGetValue(name, out tcs))
+            {
+                tcs = new TaskCompletionSource<string>();
+                _responseHeaderRequests[name] = tcs;
+            }
+
+            TaskAssert.NotCompleted(tcs.Task, "MockHttpSocketAdapter: Response header '{0}' can only be set once.", name);
+
+            tcs.SetResult(value);
+        }
+
+        public void SendResponseBodyContent(string content, Encoding encoding)
+        {
+            AssertWithMessage.NotNull(_responseHandler, "No response handler was set.");
+
+            byte[] bytes = encoding.GetBytes(content);
+
+            _responseHandler.Invoke(bytes, 0, bytes.Length);
+        }
+
+        public void SendResponseComplete()
+        {
+            TaskAssert.NotCompleted(_responseCompleteTask.Task, "MockHttpSocketAdapter: Response Complete can only be sent once.");
+
+            _responseCompleteTask.SetResult(true);
+        }
+
+        public bool IsDisposed { get; private set; }
+        public bool IsCompleted { get; private set; }
+        public string RequestContent { get { return _requestContent.ToString(); } }
+        public bool HasResponseHandler { get { return _responseHandler != null; } }
+
+
+        void IHttpSocketAdapter.AddRequestHeader(string name, string value)
+        {
+            RequestHeaders.Add(name, value);
+        }
+
+        Task IHttpSocketAdapter.CompleteRequest()
+        {
+            IsCompleted = true;
+
+            return StaticTaskResult.True;
+        }
+
+        void IDisposable.Dispose()
+        {
+            Assert.False(IsDisposed, "Calling Dispose on an adapter that was already disposed");
+
+            IsDisposed = true;
+        }
+
+        Task<string> IHttpSocketAdapter.GetResponseHeader(string headerName)
+        {
+            TaskCompletionSource<string> tcs;
+
+            if (!_responseHeaderRequests.TryGetValue(headerName, out tcs))
+            {
+                tcs = new TaskCompletionSource<string>();
+                _responseHeaderRequests[headerName] = tcs;
+            }
+
+            return tcs.Task;
+        }
+
+        Task<int> IHttpSocketAdapter.GetResponseStatusCode()
+        {
+            return _statusCodeTask.Task;
+        }
+
+        void IHttpSocketAdapter.SetResponseHandler(ResponseHandler handler)
+        {
+            AssertWithMessage.Null(_responseHandler, "SetResponseHandler was called more than once.");
+            AssertWithMessage.NotNull(handler, "SetResponseHandler was called with a null handler.");
+
+            _responseHandler = handler;
+        }
+
+        Task IHttpSocketAdapter.WaitForResponseComplete()
+        {
+            return _responseCompleteTask.Task;
+        }
+
+        Task IHttpSocketAdapter.WriteToRequestAsync(byte[] buffer, int offset, int count)
+        {
+            _requestContent.Append(Encoding.ASCII.GetString(buffer, offset, count));
+
+            return StaticTaskResult.True;
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/MockResponseHandler.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/MockResponseHandler.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    internal class MockResponseHandler
+    {
+        private StringBuilder _response = new StringBuilder();
+        private Encoding _encoding = Encoding.ASCII;
+
+        private TaskCompletionSource<object> _handlerTcs = null;
+        private bool _block;
+
+        internal MockResponseHandler(Encoding encoding)
+        {
+            _encoding = encoding;
+        }
+
+        internal string Response
+        {
+            get { return _response.ToString(); }
+        }
+
+        internal bool Block
+        {
+            get { return _block; }
+            set
+            {
+                _block = value;
+
+                if (!_block && _handlerTcs != null)
+                {
+                    TaskCompletionSource<object> completedTcs = _handlerTcs;
+
+                    _handlerTcs = null;
+
+                    completedTcs.SetResult(null);
+                }
+            }
+        }
+
+        internal Task HandlerMethod(byte[] buffer, int index, int count)
+        {
+            AssertWithMessage.Null(_handlerTcs, "More than one call to HandlerMethod is happening at the same time");
+
+            TaskCompletionSource<object> handlerTcs = new TaskCompletionSource<object>();
+
+            try
+            {
+                _response.Append(_encoding.GetString(buffer, index, count));
+
+                if (Block)
+                {
+                    _handlerTcs = handlerTcs;
+                }
+                else
+                {
+                    handlerTcs.SetResult(null);
+                }
+            }
+            catch (Exception ex)
+            {
+                handlerTcs.SetException(ex);
+            }
+
+            return handlerTcs.Task;
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/MockScriptInjectionFilterContext.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/MockScriptInjectionFilterContext.cs
@@ -1,0 +1,52 @@
+﻿using System.IO;
+using System.Text;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    public class MockScriptInjectionFilterContext : IScriptInjectionFilterContext
+    {
+        private MemoryStream _responseBody = new MemoryStream();
+        private string _requestPath;
+        private string _contentType;
+
+        public MockScriptInjectionFilterContext(string requestPath = "http://localhost:2468/Default.html", string contentType = "text/html")
+        {
+            _requestPath = requestPath;
+            _contentType = contentType;
+        }
+
+        public string GetResponseBody(Encoding encoding)
+        {
+            long originalPosition = _responseBody.Position;
+
+            try
+            {
+                _responseBody.Seek(0, SeekOrigin.Begin);
+
+                byte[] buffer = new byte[_responseBody.Length];
+                _responseBody.Read(buffer, 0, buffer.Length);
+
+                return encoding.GetString(buffer, 0, buffer.Length);
+            }
+            finally
+            {
+                _responseBody.Position = originalPosition;
+            }
+        }
+
+        string IScriptInjectionFilterContext.RequestPath
+        {
+            get { return _requestPath; }
+        }
+
+        Stream IScriptInjectionFilterContext.ResponseBody
+        {
+            get { return _responseBody; }
+        }
+
+        string IScriptInjectionFilterContext.ResponseContentType
+        {
+            get { return _contentType; }
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/MockSocketAdapter.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/MockSocketAdapter.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    internal class MockSocketAdapter : ISocketAdapter
+    {
+        private TaskCompletionSource<int> _receiveTcs = null;
+
+        private ArraySegment<byte>? _currentBytesToSend = null;
+        private ArraySegment<byte> _receiverBuffer = new ArraySegment<byte>();
+        private Queue<ArraySegment<byte>> _bytesToSend = new Queue<ArraySegment<byte>>();
+
+        private StringBuilder _sentContent = new StringBuilder();
+
+        private bool _disposed = false;
+        private bool _throwExceptionOnNextSendAsync = false;
+
+        public string SentContent
+        {
+            get { return _sentContent.ToString(); }
+        }
+
+        private ArraySegment<byte>? CurrentBytesToSend
+        {
+            get
+            {
+                if (_currentBytesToSend == null && _bytesToSend.Count > 0)
+                {
+                    _currentBytesToSend = _bytesToSend.Dequeue();
+                }
+
+                return _currentBytesToSend;
+            }
+        }
+
+        public bool IsClosed
+        {
+            get { return _disposed; }
+        }
+
+        internal void ThrowExceptionOnNextSendAsync()
+        {
+            _throwExceptionOnNextSendAsync = true;
+        }
+
+        internal void ThrowExceptionFromReceiveAsync(string message = "An error occurred.")
+        {
+            if (_receiveTcs != null)
+            {
+                _receiveTcs.TrySetException(new Exception(message));
+                _receiveTcs = null;
+            }
+        }
+
+        public void SendString(string data, Encoding encoding)
+        {
+            byte[] bytes = encoding.GetBytes(data);
+
+            SendBytes(bytes, 0, bytes.Length);
+        }
+
+        public void SendBytes(byte[] buffer, int offset, int count)
+        {
+            _bytesToSend.Enqueue(new ArraySegment<byte>(buffer, offset, count));
+
+            PushBytesToReceiver();
+        }
+
+        private void PushBytesToReceiver()
+        {
+            if (_receiveTcs != null && CurrentBytesToSend != null)
+            {
+                int bytesLeftInReceiverBuffer = _receiverBuffer.Count;
+                int positionInReceiverBuffer = _receiverBuffer.Offset;
+                int bytesSent = 0;
+
+                while (bytesLeftInReceiverBuffer > 0 && CurrentBytesToSend != null)
+                {
+                    int bytesToSend = Math.Min(bytesLeftInReceiverBuffer, CurrentBytesToSend.Value.Count);
+
+                    Array.Copy(CurrentBytesToSend.Value.Array, CurrentBytesToSend.Value.Offset, _receiverBuffer.Array, positionInReceiverBuffer, bytesToSend);
+
+                    if (bytesToSend == CurrentBytesToSend.Value.Count)
+                    {
+                        _currentBytesToSend = null;
+                    }
+                    else
+                    {
+                        _currentBytesToSend = new ArraySegment<byte>(
+                            CurrentBytesToSend.Value.Array,
+                            CurrentBytesToSend.Value.Offset + bytesToSend,
+                            CurrentBytesToSend.Value.Count - bytesToSend);
+                    }
+
+                    bytesSent += bytesToSend;
+
+                    if (bytesToSend == bytesLeftInReceiverBuffer)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        bytesLeftInReceiverBuffer -= bytesToSend;
+                        positionInReceiverBuffer += bytesToSend;
+                    }
+                }
+
+                TaskCompletionSource<int> completedTcs = _receiveTcs;
+                _receiveTcs = null;
+
+                completedTcs.SetResult(bytesSent);
+            }
+        }
+
+        Task<int> ISocketAdapter.ReceiveAsync(byte[] buffer, int offset, int count)
+        {
+            Assert.False(_disposed, "ReceiveAsync was called on a socket that has been disposed.");
+
+            AssertWithMessage.Null(_receiveTcs, "Multiple calls to ReceiveAsync are occuring at the same time");
+
+            _receiveTcs = new TaskCompletionSource<int>();
+            _receiverBuffer = new ArraySegment<byte>(buffer, offset, count);
+
+            Task<int> resultTask = _receiveTcs.Task;
+
+            PushBytesToReceiver();
+
+            return resultTask;
+        }
+
+        Task ISocketAdapter.SendAsync(IList<ArraySegment<byte>> buffers)
+        {
+            Assert.False(_disposed, "SendAsync was called on a socket that has been disposed.");
+
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+
+            try
+            {
+                if (_throwExceptionOnNextSendAsync)
+                {
+                    tcs.SetException(new Exception("SendAsync after ThrowExceptionOnNextSendAsync was called."));
+                }
+                else
+                {
+                    foreach (ArraySegment<byte> buffer in buffers)
+                    {
+                        _sentContent.Append(Encoding.ASCII.GetString(buffer.Array, buffer.Offset, buffer.Count));
+                    }
+
+                    tcs.SetResult(null);
+                }
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+
+            return tcs.Task;
+        }
+
+        void IDisposable.Dispose()
+        {
+            _disposed = true;
+        }
+    }
+
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/PathUtilTest.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/PathUtilTest.cs
@@ -1,0 +1,49 @@
+﻿using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    public class PathUtilTest
+    {
+        [Fact]
+        public void NormalizeDirectoryPath_ChangesSlashesToBackslashes()
+        {
+            // Arrange
+            string input = @"c:/my/project/path/";
+            string expected = @"c:\my\project\path\";
+
+            // Act
+            string result = PathUtil.NormalizeDirectoryPath(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void NormalizeDirectoryPath_AddsTrailingSlash()
+        {
+            // Arrange
+            string input = @"c:/my/project/path";
+            string expected = @"c:\my\project\path\";
+
+            // Act
+            string result = PathUtil.NormalizeDirectoryPath(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void NormalizeDirectoryPath_ChangesToLowercase()
+        {
+            // Arrange
+            string input = @"C:/My/Project/Path/";
+            string expected = @"c:\my\project\path\";
+
+            // Act
+            string result = PathUtil.NormalizeDirectoryPath(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/RevolvingBuffersTest.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/RevolvingBuffersTest.cs
@@ -1,0 +1,566 @@
+﻿using System;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    public class RevolvingBuffersTest
+    {
+        [Fact]
+        public void RevolvingBuffers_WriteAndReadOneBuffer()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            // Act
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+            ArraySegment<char> result = buffers.GetBufferedData();
+
+            // Assert
+            Assert.Equal("Hello, world!", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_BufferedDataDoesNotChangeWhenInputBufferChanges()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+            ArraySegment<char> result = buffers.GetBufferedData();
+
+            // Act
+            data[2] = '!';
+
+            // Assert
+            Assert.Equal("Hello, world!", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_TwoWritesAndOneRead()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            // Act
+            buffers.CopyDataToBuffer(data, 0, 6);
+            buffers.CopyDataToBuffer(data, 6, 6);
+
+            // Assert
+            ArraySegment<char> result = buffers.GetBufferedData();
+
+            Assert.Equal("Hello, world", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WriteAndReadAfterRead()
+        {
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, 6);
+            buffers.GetBufferedData();
+
+            // Act
+            buffers.CopyDataToBuffer(data, 6, 6);
+
+            // Assert
+            ArraySegment<char> result = buffers.GetBufferedData();
+
+            Assert.Equal(" world", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WriteAfterReadDoesntModifyBuffer()
+        {
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, 6);
+            ArraySegment<char> result = buffers.GetBufferedData();
+
+            // Act
+            buffers.CopyDataToBuffer(data, 6, 6);
+
+            // Assert
+            Assert.Equal("Hello,", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WritesTooMuchDataToBuffer()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(10);
+
+            // Act
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+
+            // Assert
+            ArraySegment<char> result = buffers.GetBufferedData();
+
+            Assert.Equal("Hello, world!", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WritesTooMuchDataToBufferInTwoWrites()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(10);
+            buffers.CopyDataToBuffer(data, 0, 6);
+
+            // Act
+            buffers.CopyDataToBuffer(data, 6, 6);
+
+            // Assert
+            ArraySegment<char> result = buffers.GetBufferedData();
+            Assert.Equal("Hello,", GetString(result));
+
+            result = buffers.GetBufferedData();
+            Assert.Equal(" world", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WritesMoreDataIntoTheNextBuffer()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(10);
+            buffers.CopyDataToBuffer(data, 0, 6);
+            buffers.CopyDataToBuffer(data, 6, 6);
+
+            // Act
+            buffers.CopyDataToBuffer(data, 12, 1);
+
+            // Assert
+            ArraySegment<char> result = buffers.GetBufferedData();
+            Assert.Equal("Hello,", GetString(result));
+
+            result = buffers.GetBufferedData();
+            Assert.Equal(" world!", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_ReadsWithNoDataInBuffer()
+        {
+            // Arrange
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(10);
+
+            // Act
+            ArraySegment<char> result = buffers.GetBufferedData();
+
+            // Assert
+            Assert.Equal("", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_ReadsAfterAllDataIsRead()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+            buffers.GetBufferedData();
+
+            // Act
+            ArraySegment<char> result = buffers.GetBufferedData();
+
+            // Assert
+            Assert.Equal("", GetString(result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WritesIntoManyBuffers()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(10);
+
+            // Act
+            buffers.CopyDataToBuffer(data, 0, 6);
+            buffers.CopyDataToBuffer(data, 6, 6);
+            buffers.CopyDataToBuffer(data, 12, 1);
+            buffers.CopyDataToBuffer(data, 0, 6);
+
+            // Assert
+            Assert.Equal("Hello,", GetString(buffers.GetBufferedData()));
+            Assert.Equal(" world!", GetString(buffers.GetBufferedData()));
+            Assert.Equal("Hello,", GetString(buffers.GetBufferedData()));
+            Assert.Equal("", GetString(buffers.GetBufferedData()));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_ReusesAvailableBuffers()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(10);
+
+            buffers.CopyDataToBuffer(data, 0, 6); // Write to buffer 1
+            buffers.CopyDataToBuffer(data, 6, 6); // Write to buffer 2
+
+            buffers.GetBufferedData(); // Read from buffer 1
+            buffers.GetBufferedData(); // Read from buffer 2; buffer 1 is now available
+
+            // Act
+            buffers.CopyDataToBuffer(data, 7, 5); // Write to buffer 1
+
+            // Assert
+#if DEBUG
+            AssertWithMessage.Equal(2, buffers.BufferCount, "BufferCount");
+#endif
+            Assert.Equal("world", GetString(buffers.GetBufferedData()));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WritesToLargeEnoughBufferWhenASmallerBufferIsAvailable()
+        {
+            // Arrange
+            char[] data = "Hello there, world! How are you doing today?".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(10);
+
+            buffers.CopyDataToBuffer(data, 0, 6); // Write to small buffer 1
+            buffers.CopyDataToBuffer(data, 6, 6); // Write to small buffer 2
+            buffers.CopyDataToBuffer(data, 12, 6); // Write to small buffer 3
+
+            buffers.GetBufferedData(); // Read from buffer 1
+            buffers.GetBufferedData(); // Read from buffer 2; buffer 1 is now available
+            buffers.GetBufferedData(); // Read from buffer 3; buffers 1 and 2 are now available
+
+            buffers.CopyDataToBuffer(data, 3, 6); // Write to small buffer 1
+
+            // Act
+            buffers.CopyDataToBuffer(data, 20, 24);
+
+            // Assert
+            Assert.Equal("lo the", GetString(buffers.GetBufferedData()));
+            Assert.Equal("How are you doing today?", GetString(buffers.GetBufferedData()));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_GetBufferedDataAsync_ReturnsBufferedData()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+
+            // Act
+            Task<ArraySegment<char>> task = buffers.GetBufferedDataAsync();
+
+            // Assert
+            TaskAssert.Completed(task, "Task should be completed immediately.");
+            Assert.Equal("Hello, world!", GetString(task.Result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_GetBufferedDataAsync_WaitsForBufferedData()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            // Act
+            Task<ArraySegment<char>> task = buffers.GetBufferedDataAsync();
+
+            // Assert
+            TaskAssert.NotCompleted(task, "Task should not be completed until data is buffered.");
+
+            // Act
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+
+            // Assert
+            TaskAssert.Completed(task, "Task should be completed after data is buffered.");
+            Assert.Equal("Hello, world!", GetString(task.Result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_GetBufferedDataAsync_ReturnsEmptyBufferWhenDisposed()
+        {
+            // Arrange
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            // Act
+            Task<ArraySegment<char>> task = buffers.GetBufferedDataAsync();
+
+            // Assert
+            TaskAssert.NotCompleted(task, "Task should not be completed until data is buffered.");
+
+            // Act
+            buffers.Dispose();
+
+            // Assert
+            TaskAssert.Completed(task, "Task should be completed after buffers are disposed.");
+            Assert.Equal("", GetString(task.Result));
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WaitForBufferEmptyAsync_ReturnsImmediatelyIfNoData()
+        {
+            // Arrange
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            // Act
+            Task task = buffers.WaitForBufferEmptyAsync();
+
+            // Assert
+            TaskAssert.Completed(task, "Task should be completed immediately.");
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WaitForBufferEmptyAsync_ReturnsImmediatelyIfAllDataHasBeenRead()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, 3);
+            buffers.GetBufferedData(); // Read the buffer
+            buffers.GetBufferedData(); // Release the buffer and get an empty buffer
+
+            // Act
+            Task task = buffers.WaitForBufferEmptyAsync();
+
+            // Assert
+            TaskAssert.Completed(task, "Task should be completed immediately.");
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WaitForBufferEmptyAsync_WaitsAfterDataHasBeenWritten()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, 2);
+
+            // Act
+            Task task = buffers.WaitForBufferEmptyAsync();
+
+            // Assert
+            TaskAssert.NotCompleted(task, "Task should not be completed until data is read.");
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WaitForBufferEmptyAsync_WaitsWhileBufferIsRead()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, 2);
+            Task task = buffers.WaitForBufferEmptyAsync();
+
+            // Act
+            buffers.GetBufferedData(); // Read the buffer
+
+            // Assert
+            TaskAssert.NotCompleted(task, "Task should not be completed until buffer is released.");
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WaitForBufferEmptyAsync_WaitsWhileThereIsStillMoreDataToRead()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+            buffers.GetBufferedData(); // Read the buffer
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+            Task task = buffers.WaitForBufferEmptyAsync();
+
+            // Act
+            buffers.GetBufferedData(); // Release the buffer, read the next buffer
+
+            // Assert
+            TaskAssert.NotCompleted(task, "Task should not be completed while there is still more data.");
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WaitForBufferEmptyAsync_WaitsWhileThereIsStillMoreDataToReadAsync()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+            buffers.GetBufferedData(); // Read the buffer
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+            Task task = buffers.WaitForBufferEmptyAsync();
+
+            // Act
+            buffers.GetBufferedDataAsync(); // Release the buffer, read the next buffer
+
+            // Assert
+            TaskAssert.NotCompleted(task, "Task should not be completed while there is still more data.");
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WaitForBufferEmptyAsync_ReturnsAfterBufferIsReleased()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, 2);
+            buffers.GetBufferedData(); // Read the buffer
+            Task task = buffers.WaitForBufferEmptyAsync();
+
+            // Act
+            buffers.GetBufferedData(); // Release the buffer
+
+            // Assert
+            TaskAssert.Completed(task, "Task should be completed when buffer is released.");
+        }
+
+        [Fact]
+        public void RevolvingBuffers_WaitForBufferEmptyAsync_ReturnsAfterBufferIsReleasedAsync()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            buffers.CopyDataToBuffer(data, 0, 2);
+            buffers.GetBufferedData(); // Read the buffer
+            Task task = buffers.WaitForBufferEmptyAsync();
+
+            // Act
+            buffers.GetBufferedDataAsync(); // Release the buffer
+
+            // Assert
+            TaskAssert.Completed(task, "Task should be completed when buffer is released.");
+        }
+
+        [Fact]
+        public void RevolvingBuffers_InlineAsyncDisposalInteraction()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(20);
+
+            // Reader waits for a chunk of data
+            Task read1 = buffers.GetBufferedDataAsync();
+            Assert.False(read1.IsCompleted, "read1.IsCompleted");
+
+            // Writer writes some data
+            buffers.CopyDataToBuffer(data, 0, data.Length);
+            Assert.True(read1.IsCompleted, "read1.IsCompleted");
+
+            // Writer is done writing data
+            Task wait = buffers.WaitForBufferEmptyAsync();
+            Assert.False(wait.IsCompleted, "All data isn't finished until the reader releases the last buffer");
+
+            // Writer will dispose as soon as reading is complete
+            wait.ContinueWith(task =>
+            {
+                buffers.Dispose();
+            }, TaskContinuationOptions.ExecuteSynchronously);
+
+            // Reader looks for more data
+            Task<ArraySegment<char>> read2 = buffers.GetBufferedDataAsync();
+            Assert.True(wait.IsCompleted, "Wait should be completed now");
+            Assert.True(read2.IsCompleted, "Read should also return because buffers were disposed immediately");
+            AssertWithMessage.Equal("", GetString(read2.Result), "read2.Result");
+        }
+
+        [Fact]
+        public void RevolvingBuffers_Multithreaded()
+        {
+            // Arrange
+            char[] data = "Hello, world!".ToArray();
+            int iterations = 10000;
+            StringBuilder result = new StringBuilder();
+
+            string expected = String.Concat(Enumerable.Repeat("Hello, world!", iterations));
+
+            RevolvingBuffers<char> buffers = new RevolvingBuffers<char>(2);
+
+            Exception writingThreadException = null;
+            Thread writingThread = new Thread(delegate ()
+            {
+                try
+                {
+
+                    for (int i = 0; i < iterations; i++)
+                    {
+                        for (int i2 = 0; i2 < data.Length; i2++)
+                        {
+                            buffers.CopyDataToBuffer(data, i2, 1);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    writingThreadException = ex;
+                }
+            });
+
+            Exception readingThreadException = null;
+            Thread readingThread = new Thread(delegate ()
+            {
+                try
+                {
+                    while (result.Length < data.Length * iterations)
+                    {
+                        result.Append(GetString(buffers.GetBufferedData()));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    readingThreadException = ex;
+                }
+            });
+
+            // Act
+            writingThread.Start();
+            readingThread.Start();
+
+            // Assert
+            bool completed = readingThread.Join(millisecondsTimeout: 1000);
+
+            AssertWithMessage.Null(writingThreadException, "Exception in writingThread: {0}", writingThreadException);
+            AssertWithMessage.Null(readingThreadException, "Exception in readingThread: {0}", readingThreadException);
+            Assert.True(completed, "Process did not complete.");
+
+            AssertWithMessage.Equal(expected.Length, result.Length, "result.Length");
+            Assert.Equal(expected, result.ToString());
+        }
+
+        private static string GetString(ArraySegment<char> arraySegment)
+        {
+            return new string(arraySegment.ToArray());
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/ScriptInjectionFilterStreamTest.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/ScriptInjectionFilterStreamTest.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    public class ScriptInjectionFilterStreamTest
+    {
+        [Fact]
+        public void ScriptInjectionFilterStream_PassesHtmlToFilter()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext();
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("<html><head></head><body></body></html>");
+
+            // Act
+            filterStream.Write(bytesToSend, 0, bytesToSend.Length);
+
+            // Assert
+            Assert.Contains("\r\nContent-Type: text/html\r\n", serverSocket.SentContent);
+            Assert.Contains("<html><head></head><body></body></html>", serverSocket.SentContent);
+            AssertWithMessage.Equal(0, filterContext.GetResponseBody(Encoding.UTF8).Length, "No content should be sent to the response yet.");
+            Assert.False(serverSocket.IsClosed, "Server connection should not have been closed.");
+        }
+
+        [Fact]
+        public void ScriptInjectionFilterStream_PassesJavascriptDirectlyToOutput()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext();
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("var i = 1234;");
+
+            // Act
+            filterStream.Write(bytesToSend, 0, bytesToSend.Length);
+
+            // Assert
+            AssertWithMessage.Equal(0, serverSocket.SentContent.Length, "Non-HTML content shouldn't be sent to the filter.");
+            Assert.True(serverSocket.IsClosed, "Connection to VS was not closed when non-HTML content was detected.");
+            Assert.Equal("var i = 1234;", filterContext.GetResponseBody(Encoding.UTF8));
+        }
+
+        [Fact]
+        public void ScriptInjectionFilterStream_PassesCssDirectlyToOutput()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext();
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("body { font-weight: bold; }");
+
+            // Act
+            filterStream.Write(bytesToSend, 0, bytesToSend.Length);
+
+            // Assert
+            AssertWithMessage.Equal(0, serverSocket.SentContent.Length, "Non-HTML content shouldn't be sent to the filter.");
+            Assert.True(serverSocket.IsClosed, "Connection to VS was not closed when non-HTML content was detected.");
+            Assert.Equal("body { font-weight: bold; }", filterContext.GetResponseBody(Encoding.UTF8));
+        }
+
+        [Fact]
+        public void ScriptInjectionFilterStream_ChecksResponseContentType()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext(contentType: "text/javascript");
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("var myhtml = \"<html></html>\";");
+
+            // Act
+            filterStream.Write(bytesToSend, 0, bytesToSend.Length);
+
+            // Assert
+            AssertWithMessage.Equal(0, serverSocket.SentContent.Length, "Non-HTML content shouldn't be sent to the filter.");
+            Assert.True(serverSocket.IsClosed, "Connection to VS was not closed when non-HTML content was detected.");
+            Assert.Equal("var myhtml = \"<html></html>\";", filterContext.GetResponseBody(Encoding.UTF8));
+        }
+
+        [Fact]
+        public void ScriptInjectionFilterStream_CompleteFilterProcess()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext();
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("<html><head></head><body></body></html>");
+
+            // Act I - Write some bytes
+            Task writeTask = filterStream.WriteAsync(bytesToSend, 0, 20);
+
+            // Assert
+            TaskAssert.NotCompleted(writeTask, "Write task should not complete until a successful response comes from the server.");
+
+            // Act Ia - Response from the server
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.Completed(writeTask, "The write task should complete after we receive the response line from the server.");
+            Assert.Contains("<html><head></head><", serverSocket.SentContent);
+            AssertWithMessage.Equal(0, filterContext.GetResponseBody(Encoding.UTF8).Length, "No content should be sent to the response yet.");
+            Assert.False(serverSocket.IsClosed, "Server connection should not have been closed.");
+
+            // Act II - Write some more bytes
+            filterStream.Write(bytesToSend, 20, bytesToSend.Length - 20);
+
+            // Assert
+            Assert.Contains("body></body></html>", serverSocket.SentContent);
+            AssertWithMessage.Equal(0, filterContext.GetResponseBody(Encoding.UTF8).Length, "No content should be sent to the response yet.");
+            Assert.False(serverSocket.IsClosed, "Server connection should not have been closed.");
+
+            // Act III - Wait for complete
+            Task completeTask = filterStream.FlushAsync();
+
+            // Assert
+            TaskAssert.NotCompleted(completeTask, "Before response from server.");
+
+            // Act IV - Send response from server
+            serverSocket.SendString("Content-Length: 17\r\n\r\nXFiltered content", Encoding.ASCII);
+
+            // Assert
+            Assert.Equal("Filtered content", filterContext.GetResponseBody(Encoding.ASCII));
+            TaskAssert.Completed(completeTask, "After response from server.");
+            Assert.Equal(false, filterStream.ScriptInjectionTimedOut);
+        }
+
+        [Fact]
+        public void ScriptInjectionFilterStream_CompletePassthroughProcess()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext(contentType: "text/css");
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("body { font-size: xxlarge; } p { background-color: red }");
+
+            // Act I - Write some bytes
+            filterStream.Write(bytesToSend, 0, 20);
+
+            // Assert
+            Assert.Equal(filterContext.GetResponseBody(Encoding.UTF8), "body { font-size: xx");
+            Assert.True(serverSocket.IsClosed, "Server connection should be closed.");
+
+            // Act II - Write some more bytes
+            filterStream.Write(bytesToSend, 20, bytesToSend.Length - 20);
+
+            // Assert
+            Assert.Equal(filterContext.GetResponseBody(Encoding.UTF8), "body { font-size: xxlarge; } p { background-color: red }");
+
+            // Act III - Wait for complete
+            Task completeTask = filterStream.FlushAsync();
+
+            // Assert
+            TaskAssert.Completed(completeTask, "Flush should complete immediately, because the filter is not being used.");
+        }
+
+        [Fact]
+        public void ScriptInjectionFilterStream_ErrorResponseCodeFromServer()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext();
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("<html><head></head><body></body></html>");
+
+            // Act - Attempt to write some bytes
+            Task writeTask = filterStream.WriteAsync(bytesToSend, 0, 20);
+
+            // Assert
+            TaskAssert.NotCompleted(writeTask, "Task should not complete until the response line is read.");
+
+            // Act - Write an error response
+            serverSocket.SendString("HTTP/1.1 404 Not Found\r\n", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.Completed(writeTask, "Task should complete after the response line is received.");
+            Assert.Equal("<html><head></head><", filterContext.GetResponseBody(Encoding.UTF8));
+            Assert.True(serverSocket.IsClosed, "Server connection should be closed.");
+        }
+
+        [Fact]
+        public void ScriptInjectionFilterStream_ExceptionOnFirstWrite()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext();
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("<html><head></head><body></body></html>");
+
+            // Act - Attempt to write some bytes
+            serverSocket.ThrowExceptionOnNextSendAsync();
+
+            Task writeTask = filterStream.WriteAsync(bytesToSend, 0, 20);
+
+            // Assert
+            TaskAssert.NotFaulted(writeTask, "Task should not be faulted. Filter should switch to passthrough mode.");
+            Assert.Equal("<html><head></head><", filterContext.GetResponseBody(Encoding.UTF8));
+            Assert.True(serverSocket.IsClosed, "Server connection should be closed.");
+        }
+
+        [Fact]
+        public void ScriptInjectionFilterStream_ExceptionOnSubsequentWrite()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            serverSocket.SendString("HTTP/1.1 200 OK\r\n", Encoding.ASCII);
+
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext();
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("<html><head></head><body></body></html>");
+
+            // Act I - Write some bytes
+            filterStream.Write(bytesToSend, 0, 20);
+
+            // Assert
+            Assert.Contains("<html><head></head><", serverSocket.SentContent);
+            AssertWithMessage.Equal(0, filterContext.GetResponseBody(Encoding.UTF8).Length, "No content should be sent to the response yet.");
+            Assert.False(serverSocket.IsClosed, "Server connection should not have been closed.");
+
+            // Act II - Attempt to write more bytes
+            serverSocket.ThrowExceptionOnNextSendAsync();
+
+
+            Task result = filterStream.WriteAsync(bytesToSend, 20, bytesToSend.Length - 20);
+
+            // Assert
+            TaskAssert.Faulted(result, "Exception should have been re-thrown");
+            Assert.Equal("SendAsync after ThrowExceptionOnNextSendAsync was called.", result.Exception.InnerException.Message);
+        }
+
+        [Fact]
+        public void ScriptInjectionFilterStream_BecomesPassthroughOnTimeout()
+        {
+            // Arrange
+            MockSocketAdapter serverSocket = new MockSocketAdapter();
+            MockScriptInjectionFilterContext filterContext = new MockScriptInjectionFilterContext();
+
+            ScriptInjectionFilterStream filterStream = CreateFilterStream(serverSocket, filterContext);
+
+            byte[] bytesToSend = Encoding.UTF8.GetBytes("<html><head></head><body></body></html>");
+
+            // Act I - Send some bytes
+            Task writeTask = filterStream.WriteAsync(bytesToSend, 0, 20);
+
+            // Assert
+            TaskAssert.NotCompleted(writeTask, "Should be waiting for server to respond");
+
+            // Act II - Wait for the request to time out
+            System.Threading.Thread.Sleep(1100);
+
+            // Assert
+            TaskAssert.Completed(writeTask, "Write should complete when server fails to respond");
+            Assert.True(serverSocket.IsClosed, "Should become passthrough");
+            Assert.Equal("<html><head></head><", filterContext.GetResponseBody(Encoding.UTF8));
+            AssertWithMessage.Equal(true, filterStream.ScriptInjectionTimedOut, "ScriptInjectionTimedOut");
+        }
+
+        private ScriptInjectionFilterStream CreateFilterStream(MockSocketAdapter socket, IScriptInjectionFilterContext context)
+        {
+            HttpSocketAdapter httpSocket = new HttpSocketAdapter("GET", new Uri("http://localhost:1234/abcd/injectScript"), socket);
+
+            return new ScriptInjectionFilterStream(httpSocket, context);
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/SocketReaderTest.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/SocketReaderTest.cs
@@ -1,0 +1,505 @@
+﻿using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    public class SocketReaderTest
+    {
+        private readonly CancellationToken _dontCancel = new CancellationTokenSource().Token;
+
+        [Fact]
+        public void SocketReader_ReadChar_ReadsOneCharacter()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendString("ab", Encoding.Unicode);
+
+            SocketReader reader = new SocketReader(socket);
+            reader.SetEncoding(Encoding.Unicode);
+
+            // Act
+            Task<char> result = reader.ReadChar(_dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result, 'a');
+        }
+
+        [Fact]
+        public void SocketReader_ReadChar_WaitsForDataReadingOneCharacter()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+
+            SocketReader reader = new SocketReader(socket);
+            reader.SetEncoding(Encoding.Unicode);
+
+            // Act
+            Task<char> result = reader.ReadChar(_dontCancel);
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Before sending data");
+
+            // Act
+            socket.SendString("ab", Encoding.Unicode);
+
+            // Assert
+            TaskAssert.ResultEquals(result, 'a', "After sending data");
+        }
+
+        [Fact]
+        public void SocketReader_ReadChar_DoesNotWaitForDataReadingSecondCharacter()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendString("ab", Encoding.UTF8);
+
+            SocketReader reader = new SocketReader(socket);
+            reader.SetEncoding(Encoding.UTF8);
+
+            Task<char> result1 = reader.ReadChar(_dontCancel);
+
+            TaskAssert.ResultEquals(result1, 'a', "SocketReader did not read the first character in the buffer.");
+
+            // Act
+            Task<char> result2 = reader.ReadChar(_dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result2, 'b');
+        }
+
+        [Fact]
+        public void SocketReader_ReadChar_KeepsWaitingIfNotEnoughDataIsReturned()
+        {
+            // Arrange
+            byte[] sendBuffer = Encoding.UTF32.GetBytes("ΨΣ"); // Greek Psi, Sigma
+
+            MockSocketAdapter socket = new MockSocketAdapter();
+
+            SocketReader reader = new SocketReader(socket);
+            reader.SetEncoding(Encoding.UTF32);
+
+            // Act
+            Task<char> result = reader.ReadChar(_dontCancel); // Try to read first character
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Before sending any bytes");
+
+            // Act
+            socket.SendBytes(sendBuffer, 0, 1); // Send 1 byte
+
+            // Assert
+            TaskAssert.NotCompleted(result, "After sending 1 byte");
+
+            // Act
+            socket.SendBytes(sendBuffer, 1, 2); // Send 2 more bytes
+
+            // Assert
+            TaskAssert.NotCompleted(result, "After sending 2 more bytes");
+
+            // Act
+            socket.SendBytes(sendBuffer, 3, 2); // Send 2 more bytes
+
+            // Assert
+            TaskAssert.ResultEquals(result, 'Ψ', "After sending all bytes of first character.");
+
+            // Act
+            result = reader.ReadChar(_dontCancel); // Try to read second character
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Before sending remaining bytes");
+
+            // Act
+            socket.SendBytes(sendBuffer, 5, 3); // Send remaining 3 bytes
+
+            // Assert
+            TaskAssert.ResultEquals(result, 'Σ', "After sending remaining bytes");
+        }
+
+        [Fact]
+        public void SocketReader_ReadChar_TestByteByByteWithManyEncodings()
+        {
+            // Arrange
+            Encoding[] encodings = new Encoding[]
+            {
+                Encoding.UTF8,
+                Encoding.Unicode,
+                Encoding.BigEndianUnicode,
+                Encoding.UTF32
+            };
+
+            foreach (Encoding encoding in encodings)
+            {
+                MockSocketAdapter socket = new MockSocketAdapter();
+                
+                SocketReader reader = new SocketReader(socket);
+                reader.SetEncoding(encoding);
+
+                byte[] sendBuffer = encoding.GetBytes("ΨΣ");
+                Task<char>[] results = new Task<char>[2];
+
+                int currentResult = -1;
+
+                for (int i = 0; i < sendBuffer.Length; i++)
+                {
+                    if (currentResult < 0 || results[currentResult].IsCompleted)
+                    {
+                        currentResult++;
+                        results[currentResult] = reader.ReadChar(_dontCancel);
+                    }
+
+                    socket.SendBytes(sendBuffer, i, 1);
+                }
+
+                TaskAssert.ResultEquals(results[0], 'Ψ', "result[0] with encoding {0}", encoding.EncodingName);
+                TaskAssert.ResultEquals(results[1], 'Σ', "result[1] with encoding {0}", encoding.EncodingName);
+            }
+        }
+
+        [Fact]
+        public void SocketReader_ReadChar_ReturnsZeroIfCancelled()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            SocketReader reader = new SocketReader(socket);
+            Task<char> task = reader.ReadChar(cts.Token);
+
+            // Act
+            cts.Cancel();
+
+            // Assert
+            TaskAssert.ResultEquals(task, '\0');
+        }
+
+        [Fact]
+        public void SocketReader_ReadLine_ReadsOneLine()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendString("This is a test.\r\nThis is left out.\r\n", Encoding.ASCII);
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<string> result = reader.ReadLine(_dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result, "This is a test.");
+        }
+
+        [Fact]
+        public void SocketReader_ReadLine_WaitsForDataReadingOneLine()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<string> result = reader.ReadLine(_dontCancel);
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Before sending data.");
+
+            // Act
+            socket.SendString("This is a test.\r\n", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.ResultEquals(result, "This is a test.", "After sending data.");
+        }
+
+        [Fact]
+        public void SocketReader_ReadLine_WaitsForMoreDataWhenLineIncomplete()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<string> result = reader.ReadLine(_dontCancel);
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Before sending data.");
+
+            // Act
+            socket.SendString("This is the first part of the string. ", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.NotCompleted(result, "After sending first sentence.");
+
+            // Act
+            socket.SendString("This is the second part of the string.\r", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.NotCompleted(result, "After sending second sentence.");
+
+            // Act
+            socket.SendString("\nThis is an extra, third sentence.\r\n", Encoding.ASCII);
+
+            // Assert
+            TaskAssert.ResultEquals(result, "This is the first part of the string. This is the second part of the string.", "After sending data.");
+        }
+
+        [Fact]
+        public void SocketReader_ReadLine_IgnoresUnmatchedCarriageReturn()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendString("This is a test of an unmatched \r\r\n", Encoding.ASCII);
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<string> result = reader.ReadLine(_dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result, "This is a test of an unmatched \r");
+        }
+
+        [Fact]
+        public void SocketReader_ReadLine_IgnoresUnmatchedLineFeed()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendString("This is a test\rof an unmatched \n\r\n", Encoding.ASCII);
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<string> result = reader.ReadLine(_dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result, "This is a test\rof an unmatched \n");
+        }
+
+        [Fact]
+        public void SocketReader_ReadLine_ReadsLineLongerThanBuffer()
+        {
+            // Arrange
+            string lineToSend = new String('Σ', count: 20000);
+
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendString(lineToSend + "\r\n", Encoding.Unicode);
+
+            SocketReader reader = new SocketReader(socket);
+            reader.SetEncoding(Encoding.Unicode);
+
+            // Act
+            Task<string> result = reader.ReadLine(_dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result, lineToSend);
+        }
+
+        [Fact]
+        public void SocketReader_ReadLine_ReturnsEmptyStringWhenCancelled()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            SocketReader reader = new SocketReader(socket);
+            Task<string> lineResult = reader.ReadLine(cts.Token);
+
+            // Act
+            cts.Cancel();
+
+            // Assert
+            TaskAssert.ResultEquals(lineResult, String.Empty, "Task should return empty string when canceled.");
+        }
+
+        [Fact]
+        public void SocketReader_ReadLine_ReturnsEmptyStringWhenAlreadyCancelled()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<string> lineResult = reader.ReadLine(cts.Token);
+
+            // Assert
+            TaskAssert.ResultEquals(lineResult, String.Empty, "Task should return empty string when canceled.");
+        }
+
+        [Fact]
+        public void SocketReader_ReadBytesIntoResponseHandler_ReadsBytes()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendString("This is a test. This sentence isn't read.", Encoding.UTF8);
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.UTF8);
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<int> result = reader.ReadBytesIntoResponseHandler(15, handler.HandlerMethod, _dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result, 15);
+            Assert.Equal("This is a test.", handler.Response);
+        }
+
+        [Fact]
+        public void SocketReader_ReadBytesIntoResponseHandler_WaitsForData()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.Unicode);
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<int> result = reader.ReadBytesIntoResponseHandler(30, handler.HandlerMethod, _dontCancel);
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Before any data sent");
+
+            // Act
+            socket.SendString("This is ", Encoding.Unicode);
+
+            // Assert
+            TaskAssert.NotCompleted(result, "After some data sent");
+
+            // Act
+            socket.SendString("a test. And then some.", Encoding.Unicode);
+
+            // Assert
+            TaskAssert.ResultEquals(result, 30, "After all data sent");
+            Assert.Equal("This is a test.", handler.Response);
+        }
+
+        [Fact]
+        public void SocketReader_ReadBytesIntoResponseHandler_ReadsMoreBytes()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendString("This is a test. This is the next sentence.", Encoding.ASCII);
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.ASCII);
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<int> result = reader.ReadBytesIntoResponseHandler(15, handler.HandlerMethod, _dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result, 15);
+            Assert.Equal("This is a test.", handler.Response);
+
+            // Act
+            result = reader.ReadBytesIntoResponseHandler(27, handler.HandlerMethod, _dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result, 27);
+            Assert.Equal("This is a test. This is the next sentence.", handler.Response);
+        }
+
+        [Fact]
+        public void SocketReader_ReadBytesIntoResponseHandler_WaitsForHandlerToComplete()
+        {
+            // Arrange
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendString("This is a test. This sentence isn't read.", Encoding.UTF8);
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.UTF8);
+            handler.Block = true;
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<int> result = reader.ReadBytesIntoResponseHandler(15, handler.HandlerMethod, _dontCancel);
+
+            // Assert
+            TaskAssert.NotCompleted(result, "Before handler is unblocked.");
+
+            // Act
+            handler.Block = false;
+
+            // Assert
+            TaskAssert.ResultEquals(result, 15, "After handler is unblocked.");
+            Assert.Equal("This is a test.", handler.Response);
+        }
+
+        [Fact]
+        public void SocketReader_ReadBytesIntoResponseHandler_ReadMoreBytesThanBuffer()
+        {
+            // Arrange
+            string stringToSend = new String('Σ', count: 20000);
+            byte[] bufferToSend = Encoding.UTF32.GetBytes(stringToSend);
+
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendBytes(bufferToSend, 0, bufferToSend.Length);
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.UTF32);
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<int> result = reader.ReadBytesIntoResponseHandler(bufferToSend.Length, handler.HandlerMethod, _dontCancel);
+
+            // Assert
+            TaskAssert.ResultEquals(result, bufferToSend.Length);
+            Assert.Equal(stringToSend, handler.Response);
+        }
+
+        [Fact]
+        public void SocketReader_ReadBytesIntoResponseHandler_ContinuesWaitingForBytes()
+        {
+            // Arrange
+            string stringToSend = "123456789";
+            byte[] bufferToSend = Encoding.ASCII.GetBytes(stringToSend);
+
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendBytes(bufferToSend, 0, bufferToSend.Length);
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.ASCII);
+
+            SocketReader reader = new SocketReader(socket);
+
+            // Act
+            Task<int> task = reader.ReadBytesIntoResponseHandler(bufferToSend.Length + 1, handler.HandlerMethod, _dontCancel);
+
+            // Assert
+            TaskAssert.NotCompleted(task);
+        }
+
+        [Fact]
+        public void SocketReader_ReadBytesIntoResponseHandler_StopsReadingBytesIfCancelled()
+        {
+            // Arrange
+            string stringToSend = "123456789";
+            byte[] bufferToSend = Encoding.ASCII.GetBytes(stringToSend);
+
+            MockSocketAdapter socket = new MockSocketAdapter();
+            socket.SendBytes(bufferToSend, 0, bufferToSend.Length);
+
+            MockResponseHandler handler = new MockResponseHandler(Encoding.ASCII);
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            SocketReader reader = new SocketReader(socket);
+            Task<int> task = reader.ReadBytesIntoResponseHandler(bufferToSend.Length + 1, handler.HandlerMethod, cts.Token);
+
+            // Act
+            cts.Cancel();
+
+            // Assert
+            TaskAssert.ResultEquals(task, bufferToSend.Length);
+            Assert.Equal(stringToSend, handler.Response);
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/TaskAssert.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/TaskAssert.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    internal static class TaskAssert
+    {
+        public static void ResultEquals<ResultType>(Task<ResultType> task, ResultType expected, string messageFormat = null, params object[] args)
+        {
+            TaskAssert.NotFaulted(task, messageFormat, args);
+            TaskAssert.Completed(task, messageFormat, args);
+
+            if (task.Result == null)
+            {
+                if (expected == null)
+                {
+                    return;
+                }
+            }
+            else if (task.Result.Equals(expected))
+            {
+                return;
+            }
+
+            ThrowFailure(
+                GetMethodFailureMessage(nameof(ResultEquals)),
+                FormatMessage("Expected: <{0}>. Actual: <{1}>.", SafeParam(expected), SafeParam(task.Result)),
+                FormatMessage(messageFormat, args));
+        }
+
+        public static void Faulted(Task task, string messageFormat = null, params object[] args)
+        {
+            if (!task.IsFaulted)
+            {
+                TaskAssert.ThrowFailure(
+                    GetMethodFailureMessage(nameof(Faulted)),
+                    FormatMessage(messageFormat, args));
+            }
+        }
+
+        public static void NotFaulted(Task task, string messageFormat = null, params object[] args)
+        {
+            if (task.IsFaulted)
+            {
+                ThrowFailure(
+                    task.Exception,
+                    GetMethodFailureMessage(nameof(NotFaulted)),
+                    FormatMessage(task.Exception), 
+                    FormatMessage(messageFormat, args));
+            }
+        }
+
+        public static void Completed(Task task, string messageFormat = null, params object[] args)
+        {
+            TaskAssert.NotFaulted(task, messageFormat, args);
+
+            if (!task.IsCompleted)
+            {
+                ThrowFailure(
+                    GetMethodFailureMessage(nameof(Completed)),
+                    FormatMessage(messageFormat, args));
+            }
+        }
+
+        public static void NotCompleted(Task task, string messageFormat = null, params object[] args)
+        {
+            TaskAssert.NotFaulted(task, messageFormat, args);
+
+            if (task.IsCompleted)
+            {
+                ThrowFailure(
+                    GetMethodFailureMessage(nameof(NotCompleted)),
+                    FormatMessage(messageFormat, args));
+            }
+        }
+
+        private static string FormatMessage(Exception exception)
+        {
+            exception = UnwrapException(exception);
+
+            // TODO: Add this condition back with the right exception type
+            //if (exception is AssertFailedException)
+            //{
+            //    return null;
+            //}
+            //else
+            //{
+                return String.Format("{0}: {1}.", exception.GetType().Name, exception.Message);
+            //}
+        }
+
+        private static string FormatMessage(string messageFormat, params object[] messageArgs)
+        {
+            if (messageArgs == null || messageArgs.Length == 0)
+            {
+                return messageFormat;
+            }
+            else
+            {
+                return String.Format(messageFormat, messageArgs);
+            }
+        }
+
+        private static void ThrowFailure(params string[] failureMessages)
+        {
+            ThrowFailure(null, failureMessages);
+        }
+
+        private static void ThrowFailure(Exception exception, params string[] failureMessages)
+        {
+            string failureMessage = String.Join(" ", failureMessages.Where(x => !String.IsNullOrWhiteSpace(x)));
+
+            if (exception != null)
+            {
+                exception = UnwrapException(exception);
+
+                // TODO: Add this code back with the right exception type
+                //if (exception is AssertFailedException)
+                //{
+                //    throw exception;
+                //}
+
+                //throw new AssertFailedException(failureMessage, exception);
+            }
+            else
+            {
+                //throw new AssertFailedException(failureMessage);
+            }
+        }
+
+        private static Exception UnwrapException(Exception exception)
+        {
+            while (exception is AggregateException)
+            {
+                exception = ((AggregateException)exception).InnerExceptions[0];
+            }
+
+            return exception;
+        }
+
+        private static string GetMethodFailureMessage(string methodName)
+        {
+            return String.Format("{0}.{1} failed.", nameof(TaskAssert), methodName);
+        }
+
+        private static object SafeParam(object param)
+        {
+            if (param == null)
+            {
+                return "(null)";
+            }
+            else
+            {
+                return param;
+            }
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/TaskHelpersTest.cs
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/TaskHelpersTest.cs
@@ -1,0 +1,186 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.BrowserLink
+{
+    public class TaskHelpersTest
+    {
+        [Fact]
+        public void TaskHelpers_WaitWithTimeout_ReturnsCompletedTaskResult()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            TimeSpan timeout = TimeSpan.FromMilliseconds(1000);
+
+            tcs.SetResult("Hello");
+
+            // Act
+            Task<string> result = TaskHelpers.WaitWithTimeout(tcs.Task, timeout, null);
+
+            // Assert
+            TaskAssert.ResultEquals(result, "Hello");
+        }
+
+        [Fact]
+        public void TaskHelpers_WaitWithTimeout_ReturnsTaskResultWhenComplete()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            TimeSpan timeout = TimeSpan.FromMilliseconds(1000);
+
+            Task<string> result = TaskHelpers.WaitWithTimeout(tcs.Task, timeout, null);
+
+            // Act
+            tcs.SetResult("Hello");
+
+            // Assert
+            TaskAssert.ResultEquals(result, "Hello");
+        }
+
+        [Fact]
+        public void TaskHelpers_WaitWithTimeout_ReturnsTimeoutResultIfTaskNotComplete()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            TimeSpan timeout = TimeSpan.FromMilliseconds(500);
+
+            Task<string> result = TaskHelpers.WaitWithTimeout(tcs.Task, timeout, "Timed out");
+
+            // Act
+            bool completed = result.Wait(millisecondsTimeout: 550);
+
+            // Assert
+            Assert.True(completed, "Task did not time out");
+            TaskAssert.ResultEquals(result, "Timed out");
+        }
+
+        [Fact]
+        public void TaskHelpers_WaitWithTimeout_HandlesTaskFault()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            TimeSpan timeout = TimeSpan.FromMilliseconds(1000);
+
+            Task<string> result = TaskHelpers.WaitWithTimeout(tcs.Task, timeout, "Timed out");
+
+            // Act
+            tcs.SetException(new Exception("MY TEST ERROR"));
+
+            // Assert
+            TaskAssert.Faulted(result);
+        }
+
+        [Fact]
+        public void TaskHelpers_WaitWithCancellation_DoesNotCompleteUntilTaskCompletes()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            // Act
+            Task<string> result = TaskHelpers.WaitWithCancellation(tcs.Task, cts.Token, null);
+
+            // Assert
+            TaskAssert.NotCompleted(result);
+        }
+        
+        [Fact]
+        public void TaskHelpers_WaitWithCancellation_ReturnsCompletedTask()
+        {
+            // Arrange
+            Task<string> task = Task.FromResult("Hello");
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            // Act
+            Task<string> result = TaskHelpers.WaitWithCancellation(task, cts.Token, null);
+
+            // Assert
+            TaskAssert.ResultEquals(result, "Hello");
+        }
+
+        [Fact]
+        public void TaskHelpers_WaitWithCancellation_ReturnsTaskWhenCompleted()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            Task<string> result = TaskHelpers.WaitWithCancellation(tcs.Task, cts.Token, null);
+
+            // Act
+            tcs.SetResult("Hello");
+
+            // Assert
+            TaskAssert.ResultEquals(result, "Hello");
+        }
+
+        [Fact]
+        public void TaskHelpers_WaitWithCancellation_ReturnsCancelValueForCancelledToken()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            cts.Cancel();
+
+            // Act
+            Task<string> result = TaskHelpers.WaitWithCancellation(tcs.Task, cts.Token, "Cancelled");
+
+            // Assert
+            TaskAssert.ResultEquals(result, "Cancelled");
+        }
+
+        [Fact]
+        public void TaskHelpers_WaitWithCancellation_ReturnsCancelValueWhenTokenCancels()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            Task<string> result = TaskHelpers.WaitWithCancellation(tcs.Task, cts.Token, "Cancelled");
+
+            // Act
+            cts.Cancel();
+
+            // Assert
+            TaskAssert.ResultEquals(result, "Cancelled");
+        }
+
+        [Fact]
+        public void TaskHelpers_WaitWithCancellation_HandlesMultipleCancels()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            Task<string> result = TaskHelpers.WaitWithCancellation(tcs.Task, cts.Token, "Cancelled");
+
+            cts.Cancel();
+
+            // Act
+            cts.Cancel();
+
+            // Assert
+            TaskAssert.ResultEquals(result, "Cancelled");
+        }
+
+        [Fact]
+        public void TaskHelpers_WaitWithCancellation_ResturnsTaskResultIfTaskCompleteAndCanceledSimultaneously()
+        {
+            // Arrange
+            TaskCompletionSource<string> tcs = new TaskCompletionSource<string>();
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            tcs.SetResult("Not Cancelled");
+            cts.Cancel();
+
+            // Act
+            Task<string> result = TaskHelpers.WaitWithCancellation(tcs.Task, cts.Token, "Cancelled");
+
+            // Assert
+            TaskAssert.ResultEquals(result, "Not Cancelled");
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/project.json
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/project.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "keyFile": "../../tools/Key.snk",
+    "debugType": "portable"
+  },
+  "dependencies": {
+    "Microsoft.VisualStudio.Web.BrowserLink": "1.0.0",
+    "xunit": "2.2.0-*",
+    "dotnet-test-xunit": "2.2.0-*"
+  },
+  "testRunner": "xunit",
+  "frameworks": {
+    "net451": {},
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0-*"
+        },
+        "System.Diagnostics.StackTrace": "4.0.1"
+      },
+      "imports": [
+        "dotnet5.4",
+        "portable-net451+win8"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Moving BrowserLink runtime code for ASP.NET Core from WTE into GitHub, where it can be built along with the rest of the ASP.NET Core runtime. This is pretty much just a straight copy from WTE, with some name cleanup. Also added the copyright declaration to the top of each source code file.
