### PR TITLE
Set RTM build quality for browser link

### DIFF
--- a/makefile.shade
+++ b/makefile.shade
@@ -1,0 +1,6 @@
+var VERSION='0.1'
+var FULL_VERSION='0.1'
+-BuildQuality = "rtm";
+
+use-standard-lifecycle
+k-standard-goals


### PR DESCRIPTION
@pranavkm, @jodavis, @mlorbetske, @barrytang 

We want browserlink package to be 1.0.0 not 1.0.0-alpha1
