### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.VisualStudio.Web.BrowserLink.Test/Microsoft.VisualStudio.Web.BrowserLink.Test.csproj
+++ b/test/Microsoft.VisualStudio.Web.BrowserLink.Test/Microsoft.VisualStudio.Web.BrowserLink.Test.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
     <DebugType>portable</DebugType>
   </PropertyGroup>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1