### PR TITLE
Add tags

### DIFF
--- a/src/Microsoft.VisualStudio.Web.BrowserLink.Loader/project.json
+++ b/src/Microsoft.VisualStudio.Web.BrowserLink.Loader/project.json
@@ -9,6 +9,12 @@
       "CS1591"
     ]
   },
+  "packOptions": {
+    "tags": [
+      "aspnetcore",
+      "browserlink"
+    ]
+  },
   "dependencies": {
     "Microsoft.AspNetCore.Http.Abstractions": "1.0.2",
     "Microsoft.Extensions.FileProviders.Physical": "1.0.1",


### PR DESCRIPTION
Tags cannot be empty. This is failing our 1.0.5 patch build. The alternative is to add exceptions to the check for this package but I think adding the tags is a better fix.